### PR TITLE
feat: Separate keycloak configuration

### DIFF
--- a/.github/workflows/qualitygate.yml
+++ b/.github/workflows/qualitygate.yml
@@ -15,13 +15,13 @@ jobs:
         # You may pin to the exact commit or the version.
         # uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867
         uses: hashicorp/setup-terraform@v2.0.0
-        # with:
+        with:
         #   # The hostname of a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to `app.terraform.io`.
         #   cli_config_credentials_hostname: # optional, default is app.terraform.io
         #   # The API token for a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file.
         #   cli_config_credentials_token: # optional
         #   # The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.
-        #   terraform_version: # optional, default is latest
+          terraform_version: 1.2.9 # optional, default is latest
         #   # Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
         #   terraform_wrapper: # optional, default is true
       # - name: tfsec action

--- a/README.md
+++ b/README.md
@@ -132,12 +132,27 @@ Before you let Terraform create AWS resources, you need to manually create a Sec
 It is recommended to create individual secrets per SIMPHERA instance (e.g. production and staging instance).
 To create the secret, open the Secrets Manager console and click the button `Store a new secret`.
 As secret type choose `Other type of secret`. 
+The password must contain from 8 to 128 characters and must not contain any of the following: / (slash), '(single quote), "(double quote) and @ (at sign).
 Open the Plaintext tab and paste the following JSON object and enter your usernames and passwords:
 ```json
 {
-  "postgresql_password": ""
+  "postgresql_password": "<your password>"
 }
 ```
+
+Alternatively, you can create the secret with the following Powershell script:
+
+```powershell
+$region = "<your region>"
+$postgresqlCredentials = @"
+{
+    "postgresql_password" : "<your password>"
+}
+"@ | ConvertFrom-Json | ConvertTo-Json -Compress
+$postgresqlCredentials = $postgresqlCredentials -replace '([\\]*)"', '$1$1\"'
+aws secretsmanager create-secret --name <secret name> --secret-string $postgresqlCredentials --region $region
+```
+
 On the next page you can define a name for the secret. 
 Automatic credentials rotation is currently not supported by SIMPHERA, but you can <a href="#rotating-credentials">rotate secrets manually</a>.
 You have to provide the name of the secret in your Terraform variables.
@@ -147,6 +162,13 @@ The next section describes how you need to adjust your Terraform variables.
 
 For your configuration, please make a copy of the file `terraform.tfvars.example`, name it `terraform.tfvars` and open the file in a text editor. This file contains all variables that are configurable including documentation of the variables. Please adapt the values before you deploy the resources.
 
+```diff
+simpheraInstances = {
+  "production" = {
++    secretname = "<secret name>"
+    }
+}
+```
 
 ### Apply Terraform Configuration
 

--- a/k8s.tf
+++ b/k8s.tf
@@ -62,6 +62,7 @@ module "eks-addons" {
       log_group_name       = local.log_group_name,
       service_account_name = "aws-for-fluent-bit-sa"
     })]
+    dependency_update = true
   }
 
   ingress_nginx_helm_config = {
@@ -69,6 +70,7 @@ module "eks-addons" {
       internal = "false",
       scheme   = "internet-facing",
     })]
+    dependency_update = true
   }
   cluster_autoscaler_helm_config = {
     values = [templatefile("${path.module}/templates/autoscaler_values.yaml", {
@@ -76,6 +78,7 @@ module "eks-addons" {
       eks_cluster_id       = module.eks.eks_cluster_id,
       service_account_name = "cluster-autoscaler-sa"
     })]
+    dependency_update = true
   }
   depends_on = [module.eks.managed_node_groups]
 }

--- a/modules/simphera_aws_instance/postgresql.tf
+++ b/modules/simphera_aws_instance/postgresql.tf
@@ -1,5 +1,6 @@
 resource "aws_db_instance" "simphera" {
-  allocated_storage      = var.postgresqlStorage / 1024
+  allocated_storage      = var.postgresqlStorage
+  max_allocated_storage  = var.postgresqlMaxStorage
   engine                 = "postgres"
   engine_version         = var.postgresqlVersion
   instance_class         = var.db_instance_type_simphera
@@ -17,7 +18,8 @@ resource "aws_db_instance" "simphera" {
 
 resource "aws_db_instance" "keycloak" {
   count                  = 1
-  allocated_storage      = var.postgresqlStorage / 1024
+  allocated_storage      = var.postgresqlStorageKeycloak
+  max_allocated_storage  = var.postgresqlMaxStorageKeycloak
   engine                 = "postgres"
   engine_version         = var.postgresqlVersion
   instance_class         = var.db_instance_type_keycloak

--- a/modules/simphera_aws_instance/variables.tf
+++ b/modules/simphera_aws_instance/variables.tf
@@ -43,9 +43,44 @@ variable "postgresqlVersion" {
 
 variable "postgresqlStorage" {
   type        = number
-  description = "PostgreSQL Storage in MB, must be divisble by 1024"
-  default     = 640000
+  description = "PostgreSQL Storage in GiB for SIMPHERA."
+  default     = 20
+  validation {
+    condition     = 20 <= var.postgresqlStorage && var.postgresqlStorage <= 65536
+    error_message = "postgresqlStorage must be between 100 and 65536 GiB."
+  }
 }
+
+variable "postgresqlMaxStorage" {
+  type        = number
+  description = "The upper limit to which Amazon RDS can automatically scale the storage of the SIMPHERA database. Must be greater than or equal to postgresqlStorage or 0 to disable Storage Autoscaling."
+  default     = 20
+  validation {
+    condition     = 20 <= var.postgresqlMaxStorage && var.postgresqlMaxStorage <= 65536
+    error_message = "postgresqlMaxStorage must be between 20 and 65536 GiB."
+  }
+}
+
+variable "postgresqlStorageKeycloak" {
+  type        = number
+  description = "PostgreSQL Storage in GiB for Keycloak. The minimum value is 100 GiB and the maximum value is 65.536 GiB"
+  default     = 20
+  validation {
+    condition     = 20 <= var.postgresqlStorageKeycloak && var.postgresqlStorageKeycloak <= 65536
+    error_message = "var.postgresqlStorageKeycloak must be between 20 and 65536 GiB."
+  }
+}
+
+variable "postgresqlMaxStorageKeycloak" {
+  type        = number
+  description = "The upper limit to which Amazon RDS can automatically scale the storage of the Keycloak database. Must be greater than or equal to postgresqlStorage or 0 to disable Storage Autoscaling."
+  default     = 20
+  validation {
+    condition     = 20 <= var.postgresqlMaxStorageKeycloak && var.postgresqlMaxStorageKeycloak <= 65536
+    error_message = "postgresqlStorageKeycloak must be between 20 and 65536 GiB."
+  }
+}
+
 
 variable "db_instance_type_keycloak" {
   type        = string

--- a/modules/simphera_aws_instance/variables.tf
+++ b/modules/simphera_aws_instance/variables.tf
@@ -47,7 +47,7 @@ variable "postgresqlStorage" {
   default     = 20
   validation {
     condition     = 20 <= var.postgresqlStorage && var.postgresqlStorage <= 65536
-    error_message = "postgresqlStorage must be between 100 and 65536 GiB."
+    error_message = "postgresqlStorage must be between 20 and 65536 GiB."
   }
 }
 
@@ -67,7 +67,7 @@ variable "postgresqlStorageKeycloak" {
   default     = 20
   validation {
     condition     = 20 <= var.postgresqlStorageKeycloak && var.postgresqlStorageKeycloak <= 65536
-    error_message = "var.postgresqlStorageKeycloak must be between 20 and 65536 GiB."
+    error_message = "postgresqlStorageKeycloak must be between 20 and 65536 GiB."
   }
 }
 
@@ -77,7 +77,7 @@ variable "postgresqlMaxStorageKeycloak" {
   default     = 20
   validation {
     condition     = 20 <= var.postgresqlMaxStorageKeycloak && var.postgresqlMaxStorageKeycloak <= 65536
-    error_message = "postgresqlStorageKeycloak must be between 20 and 65536 GiB."
+    error_message = "postgresqlMaxStorageKeycloak must be between 20 and 65536 GiB."
   }
 }
 

--- a/simphera-instances.tf
+++ b/simphera-instances.tf
@@ -11,6 +11,9 @@ module "simphera_instance" {
   name                         = each.value.name
   postgresqlVersion            = each.value.postgresqlVersion
   postgresqlStorage            = each.value.postgresqlStorage
+  postgresqlMaxStorage         = each.value.postgresqlMaxStorage
+  postgresqlStorageKeycloak    = each.value.postgresqlStorageKeycloak
+  postgresqlMaxStorageKeycloak = each.value.postgresqlMaxStorageKeycloak
   db_instance_type_keycloak    = each.value.db_instance_type_keycloak
   db_instance_type_simphera    = each.value.db_instance_type_simphera
   k8s_namespace                = each.value.k8s_namespace

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -36,10 +36,10 @@ linuxExecutionNodeCountMin = 1
 linuxExecutionNodeCountMax = 10
 
 # Specifies whether a VM for the dSPACE Installation Manager will be deployed
-licenseServer = true
+licenseServer = false
 
 # The version of the EKS cluster.
-kubernetesVersion = "1.21"
+kubernetesVersion = "1.22"
 
 # The CIDR for the virtual private cluster.
 vpcCidr = "10.1.0.0/18"
@@ -53,28 +53,22 @@ vpcPublicSubnets = ["10.1.12.0/22", "10.1.16.0/22", "10.1.20.0/22"]
 # List of CIDRs for the database subnets.
 vpcDatabaseSubnets = ["10.1.24.0/22", "10.1.28.0/22", "10.1.32.0/22"]
 
-# Install AWS Distro for OpenTelemetry to collect cluster metrics and send them to AWS CloudWatch.
-enable_aws_open_telemetry = false
+enable_ingress_nginx = true
 
 # Install FluentBit to send container logs to CloudWatch.
-enable_aws_for_fluentbit = true
+enable_aws_for_fluentbit = false
 
 simpheraInstances = {
   "production" = {
-    name                         = "simphera-production"
+    name                         = "production"
     postgresqlVersion            = "11"
-    postgresqlStorage            = 640000
+    postgresqlStorage            = 20
+    postgresqlMaxStorage         = 100
+    postgresqlStorageKeycloak    = 20
+    postgresqlMaxStorageKeycloak = 100
     db_instance_type_keycloak    = "db.t3.large"
     db_instance_type_simphera    = "db.t3.large"
     k8s_namespace                = "simphera"
     secretname                   = "aws-simphera-dev-production"
-    secret_tls_public_file       = "wildcard.crt"
-    secret_tls_private_file      = "wildcard.key"
-    simphera_fqdn                = "simphera.example.com"
-    minio_fqdn                   = "minio.example.com"
-    keycloak_fqdn                = "keycloak.example.com"
-    license_server_fqdn          = "licenses.example.com"
-    simphera_chart_registry      = "registry.dspace.cloud"
-    simphera_image_tag           = "2022-03-14-0911-1"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "licenseServer" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the AKS cluster."
-  default     = "1.21"
+  default     = "1.22"
 }
 variable "vpcCidr" {
   type        = string
@@ -148,13 +148,16 @@ variable "map_users" {
 
 variable "simpheraInstances" {
   type = map(object({
-    name                      = string
-    postgresqlVersion         = string
-    postgresqlStorage         = number
-    db_instance_type_simphera = string
-    db_instance_type_keycloak = string
-    k8s_namespace             = string
-    secretname                = string
+    name                         = string
+    postgresqlVersion            = string
+    postgresqlStorage            = number
+    postgresqlMaxStorage         = number
+    postgresqlStorageKeycloak    = number
+    postgresqlMaxStorageKeycloak = number
+    db_instance_type_simphera    = string
+    db_instance_type_keycloak    = string
+    k8s_namespace                = string
+    secretname                   = string
   }))
   description = "A list containing the individual SIMPHERA instances, such as 'staging' and 'production'."
 


### PR DESCRIPTION
Changes:
* Add `dependency_update=true` to helm releases
* Separate `allocated_storage` for SIMPHERA and Keycloak database.
* Introduce `max_allocated_storage` for SIMPHERA and Keycloak database allowing autoscaling.
* Storage size of databases is now defined in GiB.
* Setting the default version of Kubernetes to 1.22
