### PR TITLE
Update eks blueprint addons to 4 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,14 +395,14 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.59.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks"></a> [eks](#module\_eks) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git | v4.25.0 |
-| <a name="module_eks-addons"></a> [eks-addons](#module\_eks-addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons | v4.25.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git | v4.27.0 |
+| <a name="module_eks-addons"></a> [eks-addons](#module\_eks-addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons | v4.27.0 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4 |
 | <a name="module_simphera_instance"></a> [simphera\_instance](#module\_simphera\_instance) | ./modules/simphera_aws_instance | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v3.11.0 |

--- a/k8s.tf
+++ b/k8s.tf
@@ -1,7 +1,7 @@
 
 
 module "eks" {
-  source                                 = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git?ref=v4.25.0"
+  source                                 = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git?ref=v4.27.0"
   cluster_version                        = var.kubernetesVersion
   cluster_name                           = var.infrastructurename
   vpc_id                                 = module.vpc.vpc_id
@@ -45,7 +45,7 @@ module "eks" {
 
 
 module "eks-addons" {
-  source                              = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.25.0"
+  source                              = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.27.0"
   eks_cluster_id                      = module.eks.eks_cluster_id
   enable_amazon_eks_vpc_cni           = true
   enable_amazon_eks_coredns           = true


### PR DESCRIPTION
Updated the eks addons to version [4.27](https://github.com/aws-ia/terraform-aws-eks-blueprints/releases/tag/v4.27.0)  due to an urgent [bugfix](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1523) that breaks terraform init.