### PR TITLE
Add database endpoints as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.59.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.61.0 |
 
 ## Modules
 
@@ -487,6 +487,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | Name | Description |
 |------|-------------|
 | <a name="output_backup_vaults"></a> [backup\_vaults](#output\_backup\_vaults) | Backups vaults from all SIMPHERA instances. |
+| <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_s3_buckets"></a> [s3\_buckets](#output\_s3\_buckets) | S3 buckets from all SIMPHERA instances. |
 <!-- END_TF_DOCS -->

--- a/modules/simphera_aws_instance/outputs.tf
+++ b/modules/simphera_aws_instance/outputs.tf
@@ -9,6 +9,11 @@ output "database_identifiers" {
   value       = ["${aws_db_instance.simphera.identifier}", "${aws_db_instance.keycloak.identifier}"]
 }
 
+output "database_endpoints" {
+  description = "Endpoints of the SIMPHERA and Keycloak databases created for this SIMPHERA instance."
+  value       = ["${aws_db_instance.simphera.endpoint}", "${aws_db_instance.keycloak.endpoint}"]
+}
+
 output "s3_buckets" {
   description = "S3 buckets created for this SIMPHERA instance."
   value       = ["${aws_s3_bucket.bucket.bucket}"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "database_identifiers" {
   value       = flatten([for name, instance in module.simphera_instance : instance.database_identifiers])
 }
 
+output "database_endpoints" {
+  description = "Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances."
+  value       = flatten([for name, instance in module.simphera_instance : instance.database_endpoints])
+}
+
 output "s3_buckets" {
   description = "S3 buckets from all SIMPHERA instances."
   value       = local.s3_buckets


### PR DESCRIPTION
Adds outputs to both modules that enable the user to directly access the database endpoints without gaving to use an aws cli command before.