### PR TITLE
Various fixes and clarifications in README and state-backend-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ aws configure set aws_session_token "<your_session_token>"
 ```
 
 Access credentials are typically stored in `~/.aws/credentials` and configurations in `~/.aws/config`.
-There are [various ways](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) on how to authenticate, to run terraform.
+There are [various ways](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) on how to authenticate, to run Terraform.
 This depends on your specific setup.
 
 Verify connectivity and your access credentials by executing following command:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ aws configure set aws_session_token "<your_session_token>"
 ```
 
 Access credentials are typically stored in `~/.aws/credentials` and configurations in `~/.aws/config`.
+There are [various ways](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) on how to authenticate, to run terraform.
+This depends on your specific setup.
 
 Verify connectivity and your access credentials by executing following command:
 ```bash

--- a/state-backend-template
+++ b/state-backend-template
@@ -3,6 +3,7 @@ terraform {
   backend "s3" {
     bucket = "terraform-state"
     key    = "simphera.tfstate"
-    region = var.region
+    #The region of the bucket (same region as your deployment, ie. var.region).
+    region = "eu-central-1"
   }
 }

--- a/state-backend-template
+++ b/state-backend-template
@@ -1,8 +1,13 @@
 
 terraform {
   backend "s3" {
+    #The name of the bucket to be used to store the terraform state. You need to create this container manually.
     bucket = "terraform-state"
+
+    #The name of the file to be used inside the container to be used for this terraform state.
     key    = "simphera.tfstate"
-    region = "eu-central-1" #Same region as specified in your deployment, ie. var.region.
+    
+    #The region of the bucket.
+    region = "eu-central-1"
   }
 }

--- a/state-backend-template
+++ b/state-backend-template
@@ -3,7 +3,6 @@ terraform {
   backend "s3" {
     bucket = "terraform-state"
     key    = "simphera.tfstate"
-    #The region of the bucket (same region as your deployment, ie. var.region).
-    region = "eu-central-1"
+    region = "eu-central-1" #Same region as specified in your deployment, ie. var.region.
   }
 }


### PR DESCRIPTION
-Added session token to 'aws configure' command
-Added verification step for 'aws configure' command (also necessary to obtain ARN for your account)
-Added missing 'Principal' field in S3 policy
-Added clarification after 'terraform apply' step, stating that admin account is preferable but other user account with necessary permissions granted can also be used
-Added clarification/fix for region in state-backend-template ()