### PR TITLE
Update main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.47 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.9.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |
 
@@ -426,7 +426,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.61.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.47 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = "~> 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.47"
+      # beginning with version 5.0 some arguments are removed from resource "aws_vpc".
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Set provider aws to NOT use version 5.0.0
- Version 5.0.0 does not support "enable_classiclink" for resource "aws_vpc" anymore.