### PR TITLE
Remove creation token

### DIFF
--- a/storages.tf
+++ b/storages.tf
@@ -3,10 +3,9 @@ locals {
 }
 
 resource "aws_efs_file_system" "efs_file_system" {
-  creation_token = "efs-sile-system"
   encrypted      = true
   tags = {
-    Name = "efs-sile-system"
+    Name = "efs-file-system"
   }
 }
 

--- a/storages.tf
+++ b/storages.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_efs_file_system" "efs_file_system" {
-  encrypted      = true
+  encrypted = true
   tags = {
     Name = "efs-file-system"
   }


### PR DESCRIPTION
creation_token (optional) - A unique name (a maximum of 64 characters are allowed) used as reference when creating the Elastic File System to ensure idempotent file system creation. By default generated by Terraform. (ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system#creation_token)

It's easier to just remove the value so value will be generated by terraform than to manually ensure unique value.