### PR TITLE
Add eks aws ebs csi driver as default addon

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -19,18 +19,18 @@ module "eks" {
 
 
 module "eks-addons" {
-  source                              = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.32.1"
-  eks_cluster_id                      = module.eks.eks_cluster_id
-  enable_amazon_eks_vpc_cni           = true
-  enable_amazon_eks_coredns           = true
-  enable_amazon_eks_kube_proxy        = true
-  enable_aws_efs_csi_driver           = true
-  enable_aws_ebs_csi_driver           = true
-  enable_aws_load_balancer_controller = false
-  enable_cluster_autoscaler           = true
-  enable_aws_for_fluentbit            = var.enable_aws_for_fluentbit
-  enable_ingress_nginx                = var.enable_ingress_nginx
-  tags                                = var.tags
+  source                               = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.32.1"
+  eks_cluster_id                       = module.eks.eks_cluster_id
+  enable_amazon_eks_vpc_cni            = true
+  enable_amazon_eks_coredns            = true
+  enable_amazon_eks_kube_proxy         = true
+  enable_aws_efs_csi_driver            = true
+  enable_amazon_eks_aws_ebs_csi_driver = true
+  enable_aws_load_balancer_controller  = false
+  enable_cluster_autoscaler            = true
+  enable_aws_for_fluentbit             = var.enable_aws_for_fluentbit
+  enable_ingress_nginx                 = var.enable_ingress_nginx
+  tags                                 = var.tags
   aws_for_fluentbit_helm_config = {
     values = [templatefile("${path.module}/templates/fluentbit_values.yaml", {
       aws_region           = data.aws_region.current.name,

--- a/k8s.tf
+++ b/k8s.tf
@@ -25,6 +25,7 @@ module "eks-addons" {
   enable_amazon_eks_coredns           = true
   enable_amazon_eks_kube_proxy        = true
   enable_aws_efs_csi_driver           = true
+  enable_aws_ebs_csi_driver           = true
   enable_aws_load_balancer_controller = false
   enable_cluster_autoscaler           = true
   enable_aws_for_fluentbit            = var.enable_aws_for_fluentbit


### PR DESCRIPTION
Adds default installation of eks aws ebs csi driver so that we can create persistent volume claims based on the gp2 storage class