### PR TITLE
Add variable ami_type for GPU node group

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -55,6 +55,7 @@ locals {
       max_size        = var.gpuNodeCountMax
       min_size        = var.gpuNodeCountMin
       disk_size       = var.gpuNodeDiskSize
+      ami_type        = var.amiTypeGpu
       k8s_labels = {
         "purpose" = "gpu"
       }

--- a/locals.tf
+++ b/locals.tf
@@ -55,7 +55,7 @@ locals {
       max_size        = var.gpuNodeCountMax
       min_size        = var.gpuNodeCountMin
       disk_size       = var.gpuNodeDiskSize
-      ami_type        = var.amiTypeGpu
+      ami_type        = var.gpuAmiType
       k8s_labels = {
         "purpose" = "gpu"
       }

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,7 @@ variable "gpuNodeDiskSize" {
 
 variable "gpuAmiType" {
   type        = string
-  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values are AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64."
+  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group."
   default     = "AL2_x86_64"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,13 @@ variable "gpuNodeDiskSize" {
   description = "The disk size in GiB of the nodes for the gpu job execution"
   default     = 100
 }
+
+variable "gpuAmiType" {
+  type        = string
+  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values are AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64."
+  default     = "AL2_x86_64_GPU"
+}
+
 variable "licenseServer" {
   type        = bool
   description = "Specifies whether a license server VM will be created."
@@ -214,8 +221,3 @@ variable "cloudwatch_retention" {
   type        = number
 }
 
-variable "ami_type_gpu" {
-  type        = string
-  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values are AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64."
-  default     = "AL2_x86_64_GPU"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "gpuNodeDiskSize" {
 variable "gpuAmiType" {
   type        = string
   description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values are AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64."
-  default     = "AL2_x86_64_GPU"
+  default     = "AL2_x86_64"
 }
 
 variable "licenseServer" {

--- a/variables.tf
+++ b/variables.tf
@@ -208,11 +208,14 @@ variable "maintainance_duration" {
   type        = number
 }
 
-
 variable "cloudwatch_retention" {
   default     = 7
   description = "Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs."
   type        = number
 }
 
-
+variable "ami_type_gpu" {
+  type        = string
+  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values are AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64."
+  default     = "AL2_x86_64_GPU"
+}


### PR DESCRIPTION
The value ami_type is necessary if you want to use a GPU node group that uses an AMI with installed NVIDIA driver, e.g. AL2_x86_64_GPU.