### PR TITLE
fixing validation error in older Terraform versions

### DIFF
--- a/modules/simphera_aws_instance/variables.tf
+++ b/modules/simphera_aws_instance/variables.tf
@@ -47,7 +47,7 @@ variable "postgresqlStorage" {
   default     = 20
   validation {
     condition     = 20 <= var.postgresqlStorage && var.postgresqlStorage <= 65536
-    error_message = "postgresqlStorage must be between 20 and 65536 GiB."
+    error_message = "The variable postgresqlStorage must be between 20 and 65536 GiB."
   }
 }
 
@@ -57,7 +57,7 @@ variable "postgresqlMaxStorage" {
   default     = 20
   validation {
     condition     = 20 <= var.postgresqlMaxStorage && var.postgresqlMaxStorage <= 65536
-    error_message = "postgresqlMaxStorage must be between 20 and 65536 GiB."
+    error_message = "The variable postgresqlMaxStorage must be between 20 and 65536 GiB."
   }
 }
 
@@ -77,7 +77,7 @@ variable "postgresqlMaxStorageKeycloak" {
   default     = 20
   validation {
     condition     = 20 <= var.postgresqlMaxStorageKeycloak && var.postgresqlMaxStorageKeycloak <= 65536
-    error_message = "postgresqlMaxStorageKeycloak must be between 20 and 65536 GiB."
+    error_message = "The variable postgresqlMaxStorageKeycloak must be between 20 and 65536 GiB."
   }
 }
 


### PR DESCRIPTION
older Terraform versions report the following error:
```
The validation error message must be at least one full sentence starting with an uppercase letter and ending with a period or question mark.
```