### PR TITLE
Allowed account ids only

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allowed_account_ids"></a> [allowed\_account\_ids](#input\_allowed\_account\_ids) | The list of account ids in which creation of resources is allowed. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
 | <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
@@ -538,6 +539,8 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | <a name="input_map_accounts"></a> [map\_accounts](#input\_map\_accounts) | Additional AWS account numbers to add to the aws-auth ConfigMap | `list(string)` | `[]` | no |
 | <a name="input_map_roles"></a> [map\_roles](#input\_map\_roles) | Additional IAM roles to add to the aws-auth ConfigMap | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_map_users"></a> [map\_users](#input\_map\_users) | Additional IAM users to add to the aws-auth ConfigMap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_profile"></a> [profile](#input\_profile) | The AWS profile used. | `string` | `"default"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region to be used. | `string` | `"eu-central-1"` | no |
 | <a name="input_scan_schedule"></a> [scan\_schedule](#input\_scan\_schedule) | 6-field Cron expression describing the scan maintenance schedule. Must not overlap with variable install\_schedule. | `string` | `"cron(0 0 * * ? *)"` | no |
 | <a name="input_simpheraInstances"></a> [simpheraInstances](#input\_simpheraInstances) | A list containing the individual SIMPHERA instances, such as 'staging' and 'production'. | <pre>map(object({<br>    name                         = string<br>    postgresqlVersion            = string<br>    postgresqlStorage            = number<br>    postgresqlMaxStorage         = number<br>    db_instance_type_simphera    = string<br>    postgresqlStorageKeycloak    = number<br>    postgresqlMaxStorageKeycloak = number<br>    db_instance_type_keycloak    = string<br>    k8s_namespace                = string<br>    secretname                   = string<br>    enable_backup_service        = bool<br>    backup_retention             = number<br>    enable_deletion_protection   = bool<br><br>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to be added to all resources. | `map(any)` | `{}` | no |
@@ -550,6 +553,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description |
 |------|-------------|
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account id used for creating resources. |
 | <a name="output_backup_vaults"></a> [backup\_vaults](#output\_backup\_vaults) | Backups vaults from all SIMPHERA instances. |
 | <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.47 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.18.1 |
 
 ## Modules
@@ -513,7 +513,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_account_ids"></a> [allowed\_account\_ids](#input\_allowed\_account\_ids) | The list of account ids in which creation of resources is allowed. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
 | <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ terraform {
 
     #The name of the file to be used inside the container to be used for this terraform state.
     key    = "simphera.tfstate"
-    
+
     #The region of the bucket (same region as your deployment, ie. var.region).
     region = "eu-central-1"
   }
@@ -152,7 +152,7 @@ Create the following [IAM policy for accessing the Terraform state bucket](https
             "Effect": "Allow",
             "Principal": {
                 "AWS": "<your_account_arn>"
-            },            
+            },
             "Action": "s3:ListBucket",
             "Resource": "arn:aws:s3:::terraform-state"
         },
@@ -160,7 +160,7 @@ Create the following [IAM policy for accessing the Terraform state bucket](https
             "Effect": "Allow",
             "Principal": {
                 "AWS": "<your_account_arn>"
-            },            
+            },
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject"
@@ -254,12 +254,12 @@ foreach ($vault in $vaults){
     aws backup delete-recovery-point --profile $profile --backup-vault-name $vault --recovery-point-arn $rp.RecoveryPointArn
   }
   foreach ($rp in $recoverypoints.RecoveryPoints){
-    Do  
-    {  
+    Do
+    {
       Start-Sleep -Seconds 10
       aws backup describe-recovery-point --profile $profile --backup-vault-name $vault --recovery-point-arn $rp.RecoveryPointArn | ConvertFrom-Json
     } while( $LASTEXITCODE -eq 0)
-  }  
+  }
   aws backup delete-backup-vault --profile $profile --backup-vault-name $vault
 }
 ```
@@ -507,7 +507,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account id to be used to create resources. | `string` | n/a | yes |
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
@@ -544,6 +543,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description |
 |------|-------------|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account id used to create resources. |
 | <a name="output_backup_vaults"></a> [backup\_vaults](#output\_backup\_vaults) | Backups vaults from all SIMPHERA instances. |
 | <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |

--- a/README.md
+++ b/README.md
@@ -513,7 +513,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_account_ids"></a> [allowed\_account\_ids](#input\_allowed\_account\_ids) | The list of account ids in which creation of resources is allowed. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
 | <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
@@ -539,8 +538,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | <a name="input_map_accounts"></a> [map\_accounts](#input\_map\_accounts) | Additional AWS account numbers to add to the aws-auth ConfigMap | `list(string)` | `[]` | no |
 | <a name="input_map_roles"></a> [map\_roles](#input\_map\_roles) | Additional IAM roles to add to the aws-auth ConfigMap | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_map_users"></a> [map\_users](#input\_map\_users) | Additional IAM users to add to the aws-auth ConfigMap | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_profile"></a> [profile](#input\_profile) | The AWS profile used. | `string` | `"default"` | no |
-| <a name="input_region"></a> [region](#input\_region) | The AWS region to be used. | `string` | `"eu-central-1"` | no |
 | <a name="input_scan_schedule"></a> [scan\_schedule](#input\_scan\_schedule) | 6-field Cron expression describing the scan maintenance schedule. Must not overlap with variable install\_schedule. | `string` | `"cron(0 0 * * ? *)"` | no |
 | <a name="input_simpheraInstances"></a> [simpheraInstances](#input\_simpheraInstances) | A list containing the individual SIMPHERA instances, such as 'staging' and 'production'. | <pre>map(object({<br>    name                         = string<br>    postgresqlVersion            = string<br>    postgresqlStorage            = number<br>    postgresqlMaxStorage         = number<br>    db_instance_type_simphera    = string<br>    postgresqlStorageKeycloak    = number<br>    postgresqlMaxStorageKeycloak = number<br>    db_instance_type_keycloak    = string<br>    k8s_namespace                = string<br>    secretname                   = string<br>    enable_backup_service        = bool<br>    backup_retention             = number<br>    enable_deletion_protection   = bool<br><br>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to be added to all resources. | `map(any)` | `{}` | no |
@@ -553,7 +550,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description |
 |------|-------------|
-| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account id used for creating resources. |
 | <a name="output_backup_vaults"></a> [backup\_vaults](#output\_backup\_vaults) | Backups vaults from all SIMPHERA instances. |
 | <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |

--- a/README.md
+++ b/README.md
@@ -451,13 +451,14 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.47 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.18.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks"></a> [eks](#module\_eks) | git::<https://github.com/aws-ia/terraform-aws-eks-blueprints.git> | v4.32.1 |
-| <a name="module_eks-addons"></a> [eks-addons](#module\_eks-addons) | git::<https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons> | v4.32.1 |
+| <a name="module_eks"></a> [eks](#module\_eks) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git | v4.32.1 |
+| <a name="module_eks-addons"></a> [eks-addons](#module\_eks-addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons | v4.32.1 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4 |
 | <a name="module_simphera_instance"></a> [simphera\_instance](#module\_simphera\_instance) | ./modules/simphera_aws_instance | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v3.11.0 |
@@ -469,6 +470,9 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | [aws_cloudwatch_log_group.flowlogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_install_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_scan_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_efs_file_system.efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
+| [aws_efs_file_system_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy) | resource |
+| [aws_efs_mount_target.mount_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_flow_log.flowlog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_iam_instance_profile.license_server_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.flowlogs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -482,7 +486,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | [aws_kms_key.kms_key_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.bucket_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.license_server_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.license_server_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_logging.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_policy.buckets_logs_ssl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.license_server_bucket_ssl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -497,22 +500,29 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | [aws_ssm_maintenance_window_task.scan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window_task) | resource |
 | [aws_ssm_patch_baseline.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_patch_baseline) | resource |
 | [aws_ssm_patch_group.patch_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_patch_group) | resource |
+| [kubernetes_storage_class_v1.efs](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/storage_class_v1) | resource |
 | [aws_ami.amazon_linux_kernel5](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allowed_account_ids"></a> [allowed\_account\_ids](#input\_allowed\_account\_ids) | The list of account ids in which creation of resources is allowed. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
+| <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_patching"></a> [enable\_patching](#input\_enable\_patching) | Scans license server EC2 instance and EKS nodes for updates. Installs patches on license server automatically. EKS nodes need to be updated manually. | `bool` | `false` | no |
+| <a name="input_gpuAmiType"></a> [gpuAmiType](#input\_gpuAmiType) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. | `string` | `"AL2_x86_64"` | no |
 | <a name="input_gpuNodeCountMax"></a> [gpuNodeCountMax](#input\_gpuNodeCountMax) | The maximum number of nodes for gpu job execution | `number` | `12` | no |
 | <a name="input_gpuNodeCountMin"></a> [gpuNodeCountMin](#input\_gpuNodeCountMin) | The minimum number of nodes for gpu job execution | `number` | `0` | no |
+| <a name="input_gpuNodeDiskSize"></a> [gpuNodeDiskSize](#input\_gpuNodeDiskSize) | The disk size in GiB of the nodes for the gpu job execution | `number` | `100` | no |
 | <a name="input_gpuNodePool"></a> [gpuNodePool](#input\_gpuNodePool) | Specifies whether an additional node pool for gpu job execution is added to the kubernetes cluster | `bool` | `false` | no |
 | <a name="input_gpuNodeSize"></a> [gpuNodeSize](#input\_gpuNodeSize) | The machine size of the nodes for the gpu job execution | `list(string)` | <pre>[<br>  "p3.2xlarge"<br>]</pre> | no |
 | <a name="input_infrastructurename"></a> [infrastructurename](#input\_infrastructurename) | The name of the infrastructure. e.g. simphera-infra | `string` | n/a | yes |
@@ -543,7 +553,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Description |
 |------|-------------|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account id used to create resources. |
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account id used for creating resources. |
 | <a name="output_backup_vaults"></a> [backup\_vaults](#output\_backup\_vaults) | Backups vaults from all SIMPHERA instances. |
 | <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,7 @@ locals {
   infrastructurename                        = var.infrastructurename
   log_group_name                            = "/${module.eks.eks_cluster_id}/worker-fluentbit-logs"
   account_id                                = data.aws_caller_identity.current.account_id
+  region                                    = data.aws_region.current.name
   license_server_role                       = "${local.infrastructurename}-license-server-role"
   license_server_policy                     = "${local.infrastructurename}-license-server-policy"
   license_server_bucket_name                = "${local.infrastructurename}-license-server-bucket"

--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@
 locals {
   infrastructurename                        = var.infrastructurename
   log_group_name                            = "/${module.eks.eks_cluster_id}/worker-fluentbit-logs"
-  allowed_account_ids                       = [var.account_id]
+  account_id                                = data.aws_caller_identity.current.account_id
   license_server_role                       = "${local.infrastructurename}-license-server-role"
   license_server_policy                     = "${local.infrastructurename}-license-server-policy"
   license_server_bucket_name                = "${local.infrastructurename}-license-server-bucket"

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,6 @@ locals {
   infrastructurename                        = var.infrastructurename
   log_group_name                            = "/${module.eks.eks_cluster_id}/worker-fluentbit-logs"
   account_id                                = data.aws_caller_identity.current.account_id
-  region                                    = data.aws_region.current.name
   license_server_role                       = "${local.infrastructurename}-license-server-role"
   license_server_policy                     = "${local.infrastructurename}-license-server-policy"
   license_server_bucket_name                = "${local.infrastructurename}-license-server-bucket"

--- a/logging.tf
+++ b/logging.tf
@@ -59,7 +59,7 @@ resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
         {
             "Effect": "Allow",
             "Principal": {
-                "Service": "logs.${local.region}.amazonaws.com"
+                "Service": "logs.${var.region}.amazonaws.com"
             },
             "Action": [
                 "kms:Encrypt*",
@@ -71,7 +71,7 @@ resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
             "Resource": "*",
             "Condition": {
                 "ArnLike": {
-                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${local.region}:${local.account_id}:*"
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${var.region}:${local.account_id}:*"
                 }
             }
         }

--- a/logging.tf
+++ b/logging.tf
@@ -51,7 +51,7 @@ resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
             "Sid": "Enable IAM User Permissions",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::${var.account_id}:root"
+                "AWS": "arn:aws:iam::${local.account_id}:root"
             },
             "Action": "kms:*",
             "Resource": "*"
@@ -71,10 +71,10 @@ resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
             "Resource": "*",
             "Condition": {
                 "ArnLike": {
-                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${var.region}:${var.account_id}:*"
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${var.region}:${local.account_id}:*"
                 }
             }
-        }    
+        }
     ]
 }
 POLICY

--- a/logging.tf
+++ b/logging.tf
@@ -59,7 +59,7 @@ resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
         {
             "Effect": "Allow",
             "Principal": {
-                "Service": "logs.${var.region}.amazonaws.com"
+                "Service": "logs.${local.region}.amazonaws.com"
             },
             "Action": [
                 "kms:Encrypt*",
@@ -71,7 +71,7 @@ resource "aws_kms_key" "kms_key_cloudwatch_log_group" {
             "Resource": "*",
             "Condition": {
                 "ArnLike": {
-                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${var.region}:${local.account_id}:*"
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${local.region}:${local.account_id}:*"
                 }
             }
         }

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,12 @@ terraform {
   }
 }
 
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = var.allowed_account_ids
+  profile             = var.profile
+}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_eks_cluster" "cluster" {

--- a/main.tf
+++ b/main.tf
@@ -22,9 +22,12 @@ terraform {
 }
 provider "aws" {
   region              = var.region
-  allowed_account_ids = local.allowed_account_ids
+  allowed_account_ids = var.allowed_account_ids
   profile             = var.profile
 }
+
+data "aws_caller_identity" "current" {}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.eks_cluster_id
 }

--- a/main.tf
+++ b/main.tf
@@ -22,9 +22,8 @@ terraform {
 }
 
 provider "aws" {
-  region              = var.region
-  allowed_account_ids = var.allowed_account_ids
-  profile             = var.profile
+  region  = var.region
+  profile = var.profile
 }
 
 data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -20,11 +20,6 @@ terraform {
 
   }
 }
-provider "aws" {
-  region              = var.region
-  allowed_account_ids = var.allowed_account_ids
-  profile             = var.profile
-}
 
 data "aws_caller_identity" "current" {}
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "account_id" {
+  description = "The AWS account id used for creating resources."
+  value       = local.account_id
+}
+
 output "backup_vaults" {
   description = "Backups vaults from all SIMPHERA instances."
   value       = flatten([for name, instance in module.simphera_instance : instance.backup_vaults])

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "account_id" {
-  description = "The AWS account id used for creating resources."
-  value       = local.account_id
-}
-
 output "backup_vaults" {
   description = "Backups vaults from all SIMPHERA instances."
   value       = flatten([for name, instance in module.simphera_instance : instance.backup_vaults])

--- a/simphera-instances.tf
+++ b/simphera-instances.tf
@@ -1,7 +1,7 @@
 module "simphera_instance" {
   source                       = "./modules/simphera_aws_instance"
   for_each                     = var.simpheraInstances
-  region                       = var.region
+  region                       = local.region
   infrastructurename           = local.infrastructurename
   k8s_cluster_id               = module.eks.eks_cluster_id
   k8s_cluster_oidc_arn         = module.eks.eks_oidc_provider_arn

--- a/simphera-instances.tf
+++ b/simphera-instances.tf
@@ -1,7 +1,7 @@
 module "simphera_instance" {
   source                       = "./modules/simphera_aws_instance"
   for_each                     = var.simpheraInstances
-  region                       = local.region
+  region                       = var.region
   infrastructurename           = local.infrastructurename
   k8s_cluster_id               = module.eks.eks_cluster_id
   k8s_cluster_oidc_arn         = module.eks.eks_oidc_provider_arn

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,21 @@
+variable "profile" {
+  type        = string
+  description = "The AWS profile used."
+  default     = "default"
+}
+
+variable "allowed_account_ids" {
+  type        = list(string)
+  description = "The list of account ids in which creation of resources is allowed."
+  default     = []
+}
+
+variable "region" {
+  type        = string
+  description = "The AWS region to be used."
+  default     = "eu-central-1"
+}
+
 variable "tags" {
   type        = map(any)
   description = "The tags to be added to all resources."

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,3 @@
-variable "profile" {
-  type        = string
-  description = "The AWS profile used."
-  default     = "default"
-}
-
-variable "allowed_account_ids" {
-  type        = list(string)
-  description = "The list of account ids in which creation of resources is allowed."
-  default     = []
-}
-
-variable "region" {
-  type        = string
-  description = "The AWS region to be used."
-  default     = "eu-central-1"
-}
-
 variable "tags" {
   type        = map(any)
   description = "The tags to be added to all resources."

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,10 @@ variable "profile" {
   default     = "default"
 }
 
-variable "account_id" {
-  type        = string
-  description = "The AWS account id to be used to create resources."
+variable "allowed_account_ids" {
+  type        = list(string)
+  description = "The list of account ids in which creation of resources is allowed."
+  default     = []
 }
 
 variable "region" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,6 @@ variable "profile" {
   default     = "default"
 }
 
-variable "allowed_account_ids" {
-  type        = list(string)
-  description = "The list of account ids in which creation of resources is allowed."
-  default     = []
-}
-
 variable "region" {
   type        = string
   description = "The AWS region to be used."


### PR DESCRIPTION
Explicit specification of AWS account id is redundant, since the account gets identified automatically by specifying a profile when planning or applying Terraform. 

Instead, as discussed with @schwichti , it is more helpful to be able, but not forced, to explicitly specify allowed account ids, e.g. to avoid misuse in other accounts. Since all providers shall be removed in near future, to be able to use this configuration as a terraform module, allowed account ids are not introduced here yet. Instead, only the redundant account id gets removed now.