### PR TITLE
add eks_cluster_id to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,5 +554,6 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | <a name="output_backup_vaults"></a> [backup\_vaults](#output\_backup\_vaults) | Backups vaults from all SIMPHERA instances. |
 | <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
+| <a name="output_eks_cluster_id"></a> [eks\_cluster\_id](#output\_eks\_cluster\_id) | Amazon EKS Cluster Name |
 | <a name="output_s3_buckets"></a> [s3\_buckets](#output\_s3\_buckets) | S3 buckets from all SIMPHERA instances. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "s3_buckets" {
   description = "S3 buckets from all SIMPHERA instances."
   value       = local.s3_buckets
 }
+
+output "eks_cluster_id" {
+  description = "Amazon EKS Cluster Name"
+  value       = module.eks.eks_cluster_id
+}


### PR DESCRIPTION
When you use the reference architecture as a module and define the terraform providers on root level you need to get the `eks_cluster_id`. The eks module used inside simphera module is not visible from root level. Kubernetes and helm resources need to be created **after** the cluster has been created. To assure this, the trick is to introduce an implicit dependency between the output `eks_cluster_id` and the providers for kubernetes/helm.

```diff
module "simphera "{
 # ...
}

data "aws_eks_cluster" "cluster" {
-  name = module.eks.eks_cluster_id
+ name = module.simphera.eks_cluster_id
}
data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.eks_cluster_id
+ name = module.simphera.eks_cluster_id
}

provider "aws" {
  profile = "123456789012"
}

provider "kubernetes" {
  host                   = data.aws_eks_cluster.cluster.endpoint
  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
  token                  = data.aws_eks_cluster_auth.cluster.token
}

provider "helm" {
  kubernetes {
    host                   = data.aws_eks_cluster.cluster.endpoint
    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
    token                  = data.aws_eks_cluster_auth.cluster.token
  }
}
```