### PR TITLE
Enable nodepool scaling from zero

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -56,14 +56,14 @@ module "eks-addons" {
 
 data "aws_eks_node_group" "execnodes" {
   cluster_name    = local.infrastructurename
-  node_group_name = regex(local.arn_to_nodegroup_name_pattern, module.eks.managed_node_groups[0]["execnodes"]["managed_nodegroup_arn"][0])[0]
+  node_group_name = replace(module.eks.managed_node_groups[0]["execnodes"]["managed_nodegroup_id"][0], "${local.infrastructurename}:", "")
 
 }
 
 data "aws_eks_node_group" "gpuexecnodes" {
   count           = var.gpuNodePool ? 1 : 0
   cluster_name    = local.infrastructurename
-  node_group_name = regex(local.arn_to_nodegroup_name_pattern, module.eks.managed_node_groups[0]["gpuexecnodes"]["managed_nodegroup_arn"][0])[0]
+  node_group_name = replace(module.eks.managed_node_groups[0]["gpuexecnodes"]["managed_nodegroup_id"][0], "${local.infrastructurename}:", "")
 }
 
 resource "aws_autoscaling_group_tag" "execnodes" {

--- a/locals.tf
+++ b/locals.tf
@@ -29,20 +29,22 @@ locals {
 
   default_managed_node_pools = {
     "default" = {
-      node_group_name = "default"
-      instance_types  = var.linuxNodeSize
-      subnet_ids      = module.vpc.private_subnets
-      desired_size    = var.linuxNodeCountMin
-      max_size        = var.linuxNodeCountMax
-      min_size        = var.linuxNodeCountMin
+      node_group_name          = "default"
+      enable_node_group_prefix = false
+      instance_types           = var.linuxNodeSize
+      subnet_ids               = module.vpc.private_subnets
+      desired_size             = var.linuxNodeCountMin
+      max_size                 = var.linuxNodeCountMax
+      min_size                 = var.linuxNodeCountMin
     },
     "execnodes" = {
-      node_group_name = "execnodes"
-      instance_types  = var.linuxExecutionNodeSize
-      subnet_ids      = module.vpc.private_subnets
-      desired_size    = var.linuxExecutionNodeCountMin
-      max_size        = var.linuxExecutionNodeCountMax
-      min_size        = var.linuxExecutionNodeCountMin
+      node_group_name          = "execnodes"
+      enable_node_group_prefix = false
+      instance_types           = var.linuxExecutionNodeSize
+      subnet_ids               = module.vpc.private_subnets
+      desired_size             = var.linuxExecutionNodeCountMin
+      max_size                 = var.linuxExecutionNodeCountMax
+      min_size                 = var.linuxExecutionNodeCountMin
       k8s_labels = {
         "purpose" = "execution"
       }
@@ -59,16 +61,17 @@ locals {
 
   gpu_node_pool = {
     "gpuexecnodes" = {
-      node_group_name        = "gpuexecnodes"
-      instance_types         = var.gpuNodeSize
-      subnet_ids             = module.vpc.private_subnets
-      desired_size           = var.gpuNodeCountMin
-      max_size               = var.gpuNodeCountMax
-      min_size               = var.gpuNodeCountMin
-      disk_size              = var.gpuNodeDiskSize
-      custom_ami_id          = data.aws_ami.al2gpu_ami.image_id
-      create_launch_template = true
-      post_userdata          = local.gpuPostUserData
+      node_group_name          = "gpuexecnodes"
+      enable_node_group_prefix = false
+      instance_types           = var.gpuNodeSize
+      subnet_ids               = module.vpc.private_subnets
+      desired_size             = var.gpuNodeCountMin
+      max_size                 = var.gpuNodeCountMax
+      min_size                 = var.gpuNodeCountMin
+      disk_size                = var.gpuNodeDiskSize
+      custom_ami_id            = data.aws_ami.al2gpu_ami.image_id
+      create_launch_template   = true
+      post_userdata            = local.gpuPostUserData
       k8s_labels = {
         "purpose" = "gpu"
       }

--- a/locals.tf
+++ b/locals.tf
@@ -81,6 +81,4 @@ locals {
       ]
     }
   }
-
-  arn_to_nodegroup_name_pattern = "arn:aws:eks:${local.region}:${local.account_id}:nodegroup\\/${local.infrastructurename}\\/(.+)\\/(?:.+)"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -29,22 +29,20 @@ locals {
 
   default_managed_node_pools = {
     "default" = {
-      node_group_name          = "default"
-      enable_node_group_prefix = false
-      instance_types           = var.linuxNodeSize
-      subnet_ids               = module.vpc.private_subnets
-      desired_size             = var.linuxNodeCountMin
-      max_size                 = var.linuxNodeCountMax
-      min_size                 = var.linuxNodeCountMin
+      node_group_name = "default"
+      instance_types  = var.linuxNodeSize
+      subnet_ids      = module.vpc.private_subnets
+      desired_size    = var.linuxNodeCountMin
+      max_size        = var.linuxNodeCountMax
+      min_size        = var.linuxNodeCountMin
     },
     "execnodes" = {
-      node_group_name          = "execnodes"
-      enable_node_group_prefix = false
-      instance_types           = var.linuxExecutionNodeSize
-      subnet_ids               = module.vpc.private_subnets
-      desired_size             = var.linuxExecutionNodeCountMin
-      max_size                 = var.linuxExecutionNodeCountMax
-      min_size                 = var.linuxExecutionNodeCountMin
+      node_group_name = "execnodes"
+      instance_types  = var.linuxExecutionNodeSize
+      subnet_ids      = module.vpc.private_subnets
+      desired_size    = var.linuxExecutionNodeCountMin
+      max_size        = var.linuxExecutionNodeCountMax
+      min_size        = var.linuxExecutionNodeCountMin
       k8s_labels = {
         "purpose" = "execution"
       }
@@ -61,17 +59,16 @@ locals {
 
   gpu_node_pool = {
     "gpuexecnodes" = {
-      node_group_name          = "gpuexecnodes"
-      enable_node_group_prefix = false
-      instance_types           = var.gpuNodeSize
-      subnet_ids               = module.vpc.private_subnets
-      desired_size             = var.gpuNodeCountMin
-      max_size                 = var.gpuNodeCountMax
-      min_size                 = var.gpuNodeCountMin
-      disk_size                = var.gpuNodeDiskSize
-      custom_ami_id            = data.aws_ami.al2gpu_ami.image_id
-      create_launch_template   = true
-      post_userdata            = local.gpuPostUserData
+      node_group_name        = "gpuexecnodes"
+      instance_types         = var.gpuNodeSize
+      subnet_ids             = module.vpc.private_subnets
+      desired_size           = var.gpuNodeCountMin
+      max_size               = var.gpuNodeCountMax
+      min_size               = var.gpuNodeCountMin
+      disk_size              = var.gpuNodeDiskSize
+      custom_ami_id          = data.aws_ami.al2gpu_ami.image_id
+      create_launch_template = true
+      post_userdata          = local.gpuPostUserData
       k8s_labels = {
         "purpose" = "gpu"
       }
@@ -84,4 +81,6 @@ locals {
       ]
     }
   }
+
+  arn_to_nodegroup_name_pattern = "arn:aws:eks:${local.region}:${local.account_id}:nodegroup\\/${local.infrastructurename}\\/(.+)\\/(?:.+)"
 }


### PR DESCRIPTION
This adds _k8s.io/cluster-autoscaler/node-template/label/purpose_ tags to the generated autoscalers for the execution and gpu node pools.

The usage of this tags enables the autoscaler to realize the created nodes will have the desired label needed for the node selector used by the pods we want to deploy there.

Solution based on:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
_The following is only required if scaling up from 0 nodes. The Cluster Autoscaler will require the label tag on the ASG should a deployment have a NodeSelector, else no scaling will occur as the Cluster Autoscaler does not realise the ASG has that particular label. The tag is of the format k8s.io/cluster-autoscaler/node-template/label/<label-name>: <label-value> is the name of the label and the value of each tag specifies the label value._

You can use this kubernetes manifest to test the scaling from zero nodes.
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: node-scale-exe-test
spec:
  containers:
  - name: hello-world-execution
    image: hello-world:latest
    imagePullPolicy: IfNotPresent
  nodeSelector:
    purpose: "execution"
  tolerations:
  - key: "purpose"
    operator: "Equal"
    value: "execution"
    effect: "NoSchedule"
---
apiVersion: v1
kind: Pod
metadata:
  name: node-scale-gpu-test
spec:
  containers:
  - name: hello-world-gpu
    image: hello-world:latest
    imagePullPolicy: IfNotPresent
  nodeSelector:
    purpose: "gpu"
  tolerations:
  - key: "purpose"
    operator: "Equal"
    value: "gpu"
    effect: "NoSchedule"`
```