### PR TITLE
Enables scaling of distinct node pools from zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 
 | Name | Type |
 |------|------|
+| [aws_autoscaling_group_tag.execnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.gpuexecnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
 | [aws_cloudwatch_log_group.flowlogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_install_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_scan_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -506,6 +508,8 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | [aws_ami.amazon_linux_kernel5](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_node_group.execnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_node_group) | data source |
+| [aws_eks_node_group.gpuexecnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_node_group) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/k8s.tf
+++ b/k8s.tf
@@ -53,3 +53,39 @@ module "eks-addons" {
   cluster_autoscaler_helm_config = var.cluster_autoscaler_helm_config
   depends_on                     = [module.eks.managed_node_groups]
 }
+
+
+data "aws_eks_node_group" "execnodes" {
+  cluster_name    = local.infrastructurename
+  node_group_name = replace(module.eks.managed_node_groups[0]["execnodes"]["managed_nodegroup_id"][0], "${local.infrastructurename}:", "")
+
+}
+
+data "aws_eks_node_group" "gpuexecnodes" {
+  count           = var.gpuNodePool ? 1 : 0
+  cluster_name    = local.infrastructurename
+  node_group_name = replace(module.eks.managed_node_groups[0]["gpuexecnodes"]["managed_nodegroup_id"][0], "${local.infrastructurename}:", "")
+}
+
+resource "aws_autoscaling_group_tag" "execnodes" {
+  autoscaling_group_name = data.aws_eks_node_group.execnodes.resources[0].autoscaling_groups[0].name
+
+  tag {
+    key   = "k8s.io/cluster-autoscaler/node-template/label/purpose"
+    value = "execution"
+
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group_tag" "gpuexecnodes" {
+  count                  = var.gpuNodePool ? 1 : 0
+  autoscaling_group_name = data.aws_eks_node_group.gpuexecnodes[0].resources[0].autoscaling_groups[0].name
+
+  tag {
+    key   = "k8s.io/cluster-autoscaler/node-template/label/purpose"
+    value = "gpu"
+
+    propagate_at_launch = true
+  }
+}


### PR DESCRIPTION
This adds _k8s.io/cluster-autoscaler/node-template/label/purpose_ tags to the generated autoscalers for the execution and gpu node pools.

The usage of this tags enables the autoscaler to realize the created nodes will have the desired label needed for the node selector used by the pods we want to deploy there.

Solution based on:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
_The following is only required if scaling up from 0 nodes. The Cluster Autoscaler will require the label tag on the ASG should a deployment have a NodeSelector, else no scaling will occur as the Cluster Autoscaler does not realise the ASG has that particular label. The tag is of the format k8s.io/cluster-autoscaler/node-template/label/<label-name>: <label-value> is the name of the label and the value of each tag specifies the label value._

You can use this kubernetes manifest to test the scaling from zero nodes.
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: node-scale-exe-test
spec:
  containers:
  - name: hello-world-execution
    image: hello-world:latest
    imagePullPolicy: IfNotPresent
  nodeSelector:
    purpose: "execution"
  tolerations:
  - key: "purpose"
    operator: "Equal"
    value: "execution"
    effect: "NoSchedule"
---
apiVersion: v1
kind: Pod
metadata:
  name: node-scale-gpu-test
spec:
  containers:
  - name: hello-world-gpu
    image: hello-world:latest
    imagePullPolicy: IfNotPresent
  nodeSelector:
    purpose: "gpu"
  tolerations:
  - key: "purpose"
    operator: "Equal"
    value: "gpu"
    effect: "NoSchedule"`
```