### PR TITLE
K8s 1.28 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | <a name="input_gpuNvidiaDriverVersion"></a> [gpuNvidiaDriverVersion](#input\_gpuNvidiaDriverVersion) | The NVIDIA driver version for GPU node group. | `string` | `"535.54.03"` | no |
 | <a name="input_infrastructurename"></a> [infrastructurename](#input\_infrastructurename) | The name of the infrastructure. e.g. simphera-infra | `string` | `"simphera"` | no |
 | <a name="input_install_schedule"></a> [install\_schedule](#input\_install\_schedule) | 6-field Cron expression describing the install maintenance schedule. Must not overlap with variable scan\_schedule. | `string` | `"cron(0 3 * * ? *)"` | no |
-| <a name="input_kubernetesVersion"></a> [kubernetesVersion](#input\_kubernetesVersion) | The version of the EKS cluster. | `string` | `"1.22"` | no |
+| <a name="input_kubernetesVersion"></a> [kubernetesVersion](#input\_kubernetesVersion) | The version of the EKS cluster. | `string` | `"1.28"` | no |
 | <a name="input_licenseServer"></a> [licenseServer](#input\_licenseServer) | Specifies whether a license server VM will be created. | `bool` | `false` | no |
 | <a name="input_linuxExecutionNodeCountMax"></a> [linuxExecutionNodeCountMax](#input\_linuxExecutionNodeCountMax) | The maximum number of Linux nodes for the job execution | `number` | `10` | no |
 | <a name="input_linuxExecutionNodeCountMin"></a> [linuxExecutionNodeCountMin](#input\_linuxExecutionNodeCountMin) | The minimum number of Linux nodes for the job execution | `number` | `0` | no |

--- a/modules/simphera_aws_instance/postgresql.tf
+++ b/modules/simphera_aws_instance/postgresql.tf
@@ -35,7 +35,7 @@ resource "aws_db_instance" "simphera" {
 }
 
 resource "aws_db_instance" "keycloak" {
-  allocated_storage                   = var.postgresqlStorage
+  allocated_storage                   = var.postgresqlStorageKeycloak
   max_allocated_storage               = var.postgresqlMaxStorageKeycloak
   auto_minor_version_upgrade          = true # [RDS.13] RDS automatic minor version upgrades should be enabled
   engine                              = "postgres"

--- a/modules/simphera_aws_instance/variables.tf
+++ b/modules/simphera_aws_instance/variables.tf
@@ -50,6 +50,26 @@ variable "postgresqlMaxStorage" {
   }
 }
 
+variable "postgresqlStorageKeycloak" {
+  type        = number
+  description = "PostgreSQL Storage in GiB for Keycloak. The minimum value is 100 GiB and the maximum value is 65.536 GiB"
+  default     = 20
+  validation {
+    condition     = 20 <= var.postgresqlStorageKeycloak && var.postgresqlStorageKeycloak <= 65536
+    error_message = "postgresqlStorageKeycloak must be between 20 and 65536 GiB."
+  }
+}
+
+variable "postgresqlMaxStorageKeycloak" {
+  type        = number
+  description = "The upper limit to which Amazon RDS can automatically scale the storage of the Keycloak database. Must be greater than or equal to postgresqlStorage or 0 to disable Storage Autoscaling."
+  default     = 20
+  validation {
+    condition     = 20 <= var.postgresqlMaxStorageKeycloak && var.postgresqlMaxStorageKeycloak <= 65536
+    error_message = "The variable postgresqlMaxStorageKeycloak must be between 20 and 65536 GiB."
+  }
+}
+
 variable "db_instance_type_keycloak" {
   type        = string
   description = "PostgreSQL database instance type for Keycloak data"

--- a/modules/simphera_aws_instance/variables.tf
+++ b/modules/simphera_aws_instance/variables.tf
@@ -50,26 +50,6 @@ variable "postgresqlMaxStorage" {
   }
 }
 
-variable "postgresqlStorageKeycloak" {
-  type        = number
-  description = "PostgreSQL Storage in GiB for Keycloak. The minimum value is 100 GiB and the maximum value is 65.536 GiB"
-  default     = 20
-  validation {
-    condition     = 20 <= var.postgresqlStorageKeycloak && var.postgresqlStorageKeycloak <= 65536
-    error_message = "postgresqlStorageKeycloak must be between 20 and 65536 GiB."
-  }
-}
-
-variable "postgresqlMaxStorageKeycloak" {
-  type        = number
-  description = "The upper limit to which Amazon RDS can automatically scale the storage of the Keycloak database. Must be greater than or equal to postgresqlStorage or 0 to disable Storage Autoscaling."
-  default     = 20
-  validation {
-    condition     = 20 <= var.postgresqlMaxStorageKeycloak && var.postgresqlMaxStorageKeycloak <= 65536
-    error_message = "The variable postgresqlMaxStorageKeycloak must be between 20 and 65536 GiB."
-  }
-}
-
 variable "db_instance_type_keycloak" {
   type        = string
   description = "PostgreSQL database instance type for Keycloak data"

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -23,9 +23,9 @@ provider "helm" {
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
     #token                  = data.aws_eks_cluster_auth.cluster.token
     exec {
-        api_version = "client.authentication.k8s.io/v1beta1"
-        args        = ["eks", "--profile=${var.profile}", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
-        command     = "aws"
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "--profile=${var.profile}", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+      command     = "aws"
     }
   }
 }

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -22,10 +22,12 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.cluster.token
-    exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["eks", "--profile=change_me", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
-      command     = "aws"
+    
+    # Uncomment if you run into Helm timeout issues on Linux 
+    #exec {
+    #  api_version = "client.authentication.k8s.io/v1beta1"
+    #  args        = ["eks", "--profile=change_me", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+    #  command     = "aws"
     }
   }
 }

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -1,14 +1,15 @@
 data "aws_eks_cluster" "cluster" {
   name = module.eks.eks_cluster_id
 }
+
 data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.eks_cluster_id
 }
 
 provider "aws" {
-  profile = "123456789012"
+  profile = var.profile
+  region  = var.region
 }
-
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
@@ -20,8 +21,12 @@ provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-    token                  = data.aws_eks_cluster_auth.cluster.token
+    #token                  = data.aws_eks_cluster_auth.cluster.token
+    exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        args        = ["eks", "--profile=${var.profile}", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+        command     = "aws"
+    }
   }
 }
-
 

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -21,7 +21,7 @@ provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-    #token                  = data.aws_eks_cluster_auth.cluster.token
+    token                  = data.aws_eks_cluster_auth.cluster.token
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "--profile=change_me", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]

--- a/providers.tf.example
+++ b/providers.tf.example
@@ -7,8 +7,8 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 provider "aws" {
-  profile = var.profile
-  region  = var.region
+  profile = "change_me"
+  region  = "change_me"
 }
 
 provider "kubernetes" {
@@ -24,7 +24,7 @@ provider "helm" {
     #token                  = data.aws_eks_cluster_auth.cluster.token
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["eks", "--profile=${var.profile}", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+      args        = ["eks", "--profile=change_me", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
       command     = "aws"
     }
   }

--- a/state-backend-template
+++ b/state-backend-template
@@ -5,9 +5,12 @@ terraform {
     bucket = "terraform-state"
 
     #The name of the file to be used inside the container to be used for this terraform state.
-    key    = "simphera.tfstate"
-    
+    key = "simphera.tfstate"
+ 
     #The region of the bucket.
     region = "eu-central-1"
+
+    #AWS profile to use
+    profile = "wtc-development"
   }
 }

--- a/templates/nginx_values.yaml
+++ b/templates/nginx_values.yaml
@@ -8,3 +8,11 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-internal: "${internal}"
       service.beta.kubernetes.io/aws-load-balancer-target-node-labels: kubernetes.io/os=linux
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: "prometheus" 
+
+

--- a/terraform.json.example
+++ b/terraform.json.example
@@ -15,7 +15,7 @@
   "gpuNvidiaDriverVersion": "535.54.03",
   "infrastructurename": "simphera",
   "install_schedule": "cron(0 3 * * ? *)",
-  "kubernetesVersion": "1.22",
+  "kubernetesVersion": "1.28",
   "licenseServer": false,
   "linuxExecutionNodeCountMax": 10,
   "linuxExecutionNodeCountMin": 0,

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,9 +1,3 @@
-# AWS profile
-profile = "change-me"
-
-# AWS region
-region = "change-me"
-
 # Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs.
 cloudwatch_retention = 7
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,7 +8,10 @@ region = "change-me"
 cloudwatch_retention = 7
 
 # Cluster Autoscaler Helm Config
-cluster_autoscaler_helm_config = {}
+cluster_autoscaler_helm_config = {
+  # default version (9.21.0) has obsoleted image registry and deployment will fail
+  version = "9.28.0"
+}
 
 # Install FluentBit to send container logs to CloudWatch.
 enable_aws_for_fluentbit = false
@@ -46,7 +49,7 @@ infrastructurename = "simphera"
 install_schedule = "cron(0 3 * * ? *)"
 
 # The version of the EKS cluster.
-kubernetesVersion = "1.27"
+kubernetesVersion = "1.28"
 
 # Specifies whether a license server VM will be created.
 licenseServer = false
@@ -92,20 +95,20 @@ scan_schedule = "cron(0 0 * * ? *)"
 
 # A list containing the individual SIMPHERA instances, such as 'staging' and 'production'.
 simpheraInstances = {
-  "production": {
-    "backup_retention": 35,
-    "db_instance_type_keycloak": "db.t3.large",
-    "db_instance_type_simphera": "db.t3.large",
-    "enable_backup_service": true,
-    "enable_deletion_protection": true,
-    "k8s_namespace": "simphera",
-    "name": "production",
-    "postgresqlMaxStorage": 100,
-    "postgresqlMaxStorageKeycloak": 100,
-    "postgresqlStorage": 20,
-    "postgresqlStorageKeycloak": 20,
-    "postgresqlVersion": "11",
-    "secretname": "aws-simphera-dev-production"
+  "production" : {
+    "backup_retention" : 35,
+    "db_instance_type_keycloak" : "db.t3.large",
+    "db_instance_type_simphera" : "db.t3.large",
+    "enable_backup_service" : true,
+    "enable_deletion_protection" : true,
+    "k8s_namespace" : "simphera",
+    "name" : "production",
+    "postgresqlMaxStorage" : 100,
+    "postgresqlMaxStorageKeycloak" : 100,
+    "postgresqlStorage" : 20,
+    "postgresqlStorageKeycloak" : 20,
+    "postgresqlVersion" : "11",
+    "secretname" : "aws-simphera-dev-production"
   }
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,8 @@
+# AWS profile
+profile = "change-me"
 
+# AWS region
+region = "change-me"
 
 # Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs.
 cloudwatch_retention = 7
@@ -42,7 +46,7 @@ infrastructurename = "simphera"
 install_schedule = "cron(0 3 * * ? *)"
 
 # The version of the EKS cluster.
-kubernetesVersion = "1.22"
+kubernetesVersion = "1.27"
 
 # Specifies whether a license server VM will be created.
 licenseServer = false

--- a/variables.tf
+++ b/variables.tf
@@ -154,7 +154,7 @@ variable "map_roles" {
     groups   = list(string)
   }))
   description = "Additional IAM roles to add to the aws-auth ConfigMap"
-  default = []
+  default     = []
 }
 
 variable "map_users" {
@@ -164,7 +164,7 @@ variable "map_users" {
     groups   = list(string)
   }))
   description = "Additional IAM users to add to the aws-auth ConfigMap"
-  default = []
+  default     = []
 }
 
 variable "simpheraInstances" {
@@ -216,7 +216,7 @@ variable "scan_schedule" {
   default     = "cron(0 0 * * ? *)"
 }
 variable "install_schedule" {
-  type        = string  
+  type        = string
   description = "6-field Cron expression describing the install maintenance schedule. Must not overlap with variable scan_schedule."
   default     = "cron(0 3 * * ? *)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,15 @@
+variable "profile" {
+  type        = string
+  description = "AWS profile to be used"
+  default     = "my-profile"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to be used"
+  default     = "my-region"
+}
+
 variable "tags" {
   type        = map(any)
   description = "The tags to be added to all resources."
@@ -77,9 +89,9 @@ variable "gpuNodeDiskSize" {
 }
 
 variable "gpuNvidiaDriverVersion" {
-  default     = "535.54.03"
   type        = string
   description = "The NVIDIA driver version for GPU node group."
+  default     = "535.54.03"
 }
 
 variable "licenseServer" {
@@ -91,7 +103,7 @@ variable "licenseServer" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the EKS cluster."
-  default     = "1.22"
+  default     = "1.28"
 }
 variable "vpcCidr" {
   type        = string
@@ -130,28 +142,28 @@ variable "enable_ingress_nginx" {
 }
 
 variable "map_accounts" {
-  description = "Additional AWS account numbers to add to the aws-auth ConfigMap"
   type        = list(string)
+  description = "Additional AWS account numbers to add to the aws-auth ConfigMap"
   default     = []
 }
 
 variable "map_roles" {
-  description = "Additional IAM roles to add to the aws-auth ConfigMap"
   type = list(object({
     rolearn  = string
     username = string
     groups   = list(string)
   }))
+  description = "Additional IAM roles to add to the aws-auth ConfigMap"
   default = []
 }
 
 variable "map_users" {
-  description = "Additional IAM users to add to the aws-auth ConfigMap"
   type = list(object({
     userarn  = string
     username = string
     groups   = list(string)
   }))
+  description = "Additional IAM users to add to the aws-auth ConfigMap"
   default = []
 }
 
@@ -199,31 +211,31 @@ variable "enable_patching" {
 }
 
 variable "scan_schedule" {
-  description = "6-field Cron expression describing the scan maintenance schedule. Must not overlap with variable install_schedule."
   type        = string
+  description = "6-field Cron expression describing the scan maintenance schedule. Must not overlap with variable install_schedule."
   default     = "cron(0 0 * * ? *)"
 }
 variable "install_schedule" {
+  type        = string  
   description = "6-field Cron expression describing the install maintenance schedule. Must not overlap with variable scan_schedule."
-  type        = string
   default     = "cron(0 3 * * ? *)"
 }
 
 variable "maintainance_duration" {
-  default     = 3
-  description = "How long in hours for the maintenance window."
   type        = number
+  description = "How long in hours for the maintenance window."
+  default     = 3
 }
 
 variable "cloudwatch_retention" {
-  default     = 7
-  description = "Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs."
   type        = number
+  description = "Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs."
+  default     = 7
 }
 
 variable "cluster_autoscaler_helm_config" {
-  default     = {}
-  description = "Cluster Autoscaler Helm Config"
   type        = any
+  description = "Cluster Autoscaler Helm Config"
+  default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,3 @@
-variable "profile" {
-  type        = string
-  description = "AWS profile to be used"
-  default     = "my-profile"
-}
-
-variable "region" {
-  type        = string
-  description = "AWS region to be used"
-  default     = "my-region"
-}
-
 variable "tags" {
   type        = map(any)
   description = "The tags to be added to all resources."


### PR DESCRIPTION
- upgraded k8s to 1.28 (EOL: 28/10/2024)
- fixed issues with old cluster-autoscaler helm chart, used obsolete k8s image registry + helm chart and image tag are now aligned
- added exec command to helm provider, to get auth token, as per TF docs, otherwise it did not work
- moved profile and region to variables
- added aws region to main.tf/providers.tf.example, otherwise it did not work

Tested with:
Terraform v1.4.5
on linux_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.14.0
+ provider registry.terraform.io/hashicorp/aws v4.67.0
+ provider registry.terraform.io/hashicorp/cloudinit v2.3.2
+ provider registry.terraform.io/hashicorp/helm v2.11.0
+ provider registry.terraform.io/hashicorp/http v3.4.0
+ provider registry.terraform.io/hashicorp/kubernetes v2.23.0
+ provider registry.terraform.io/hashicorp/local v2.4.0
+ provider registry.terraform.io/hashicorp/null v3.2.1
+ provider registry.terraform.io/hashicorp/random v3.5.1
+ provider registry.terraform.io/hashicorp/time v0.9.1
+ provider registry.terraform.io/hashicorp/tls v4.0.4
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1