### PR TITLE
added ivs gpu node pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 |------|------|
 | [aws_autoscaling_group_tag.execnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
 | [aws_autoscaling_group_tag.gpuexecnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.gpuivsnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
 | [aws_cloudwatch_log_group.flowlogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_install_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_scan_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -510,6 +511,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_node_group.execnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_node_group) | data source |
 | [aws_eks_node_group.gpuexecnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_node_group) | data source |
+| [aws_eks_node_group.gpuivsnodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_node_group) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -530,6 +532,11 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | <a name="input_gpuNvidiaDriverVersion"></a> [gpuNvidiaDriverVersion](#input\_gpuNvidiaDriverVersion) | The NVIDIA driver version for GPU node group. | `string` | `"535.54.03"` | no |
 | <a name="input_infrastructurename"></a> [infrastructurename](#input\_infrastructurename) | The name of the infrastructure. e.g. simphera-infra | `string` | `"simphera"` | no |
 | <a name="input_install_schedule"></a> [install\_schedule](#input\_install\_schedule) | 6-field Cron expression describing the install maintenance schedule. Must not overlap with variable scan\_schedule. | `string` | `"cron(0 3 * * ? *)"` | no |
+| <a name="input_ivsGpuNodeCountMax"></a> [ivsGpuNodeCountMax](#input\_ivsGpuNodeCountMax) | The maximum number of GPU nodes nodes for IVS jobs | `number` | `2` | no |
+| <a name="input_ivsGpuNodeCountMin"></a> [ivsGpuNodeCountMin](#input\_ivsGpuNodeCountMin) | The minimum number of GPU nodes nodes for IVS jobs | `number` | `0` | no |
+| <a name="input_ivsGpuNodeDiskSize"></a> [ivsGpuNodeDiskSize](#input\_ivsGpuNodeDiskSize) | The disk size in GiB of the nodes for the IVS gpu job execution | `number` | `100` | no |
+| <a name="input_ivsGpuNodePool"></a> [ivsGpuNodePool](#input\_ivsGpuNodePool) | Specifies whether an additional node pool for IVS gpu job execution is added to the kubernetes cluster | `bool` | `false` | no |
+| <a name="input_ivsGpuNodeSize"></a> [ivsGpuNodeSize](#input\_ivsGpuNodeSize) | The machine size of the GPU nodes for IVS jobs | `list(string)` | <pre>[<br>  "g4dn.2xlarge"<br>]</pre> | no |
 | <a name="input_kubernetesVersion"></a> [kubernetesVersion](#input\_kubernetesVersion) | The version of the EKS cluster. | `string` | `"1.28"` | no |
 | <a name="input_licenseServer"></a> [licenseServer](#input\_licenseServer) | Specifies whether a license server VM will be created. | `bool` | `false` | no |
 | <a name="input_linuxExecutionNodeCountMax"></a> [linuxExecutionNodeCountMax](#input\_linuxExecutionNodeCountMax) | The maximum number of Linux nodes for the job execution | `number` | `10` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -54,7 +54,6 @@ locals {
         }
       ]
     }
-
   }
 
   gpu_node_pool = {
@@ -76,6 +75,37 @@ locals {
         {
           key      = "purpose",
           value    = "gpu",
+          "effect" = "NO_SCHEDULE"
+        }
+      ]
+    }
+  }
+
+  ivsgpu_node_pool = {
+    "gpuivsnodes" = {
+      node_group_name        = "gpuivsnodes"
+      instance_types         = var.ivsGpuNodeSize
+      subnet_ids             = module.vpc.private_subnets
+      desired_size           = var.ivsGpuNodeCountMin
+      max_size               = var.ivsGpuNodeCountMax
+      min_size               = var.ivsGpuNodeCountMin
+      disk_size              = var.ivsGpuNodeDiskSize
+      custom_ami_id          = data.aws_ami.al2gpu_ami.image_id
+      create_launch_template = true
+      post_userdata          = local.gpuPostUserData
+      k8s_labels = {
+        "product" = "ivs",
+        "purpose" = "gpu"
+      }
+      k8s_taints = [
+        {
+          key      = "purpose",
+          value    = "gpu",
+          "effect" = "NO_SCHEDULE"
+        },
+        {
+          key      = "nvidia.com/gpu",
+          value    = "",
           "effect" = "NO_SCHEDULE"
         }
       ]

--- a/terraform.json.example
+++ b/terraform.json.example
@@ -5,12 +5,19 @@
   "enable_aws_for_fluentbit": false,
   "enable_ingress_nginx": false,
   "enable_patching": false,
-  "gpuNodeCountMax": 12,
   "gpuNodeCountMin": 0,
+  "gpuNodeCountMax": 12,
   "gpuNodeDiskSize": 100,
   "gpuNodePool": false,
   "gpuNodeSize": [
     "p3.2xlarge"
+  ],
+  "ivsGpuNodeCountMin": 0,
+  "ivsGpuNodeCountMax": 2,
+  "ivsGpuNodeDiskSize": 100,
+  "ivsGpuNodePool": false,
+  "ivsGpuNodeSize": [
+    "g4dn.2xlarge"
   ],
   "gpuNvidiaDriverVersion": "535.54.03",
   "infrastructurename": "simphera",

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -33,6 +33,23 @@ gpuNodeSize = [
   "p3.2xlarge"
 ]
 
+# The minimum number of nodes for IVS gpu job execution
+ivsGpuNodeCountMin = 0
+
+# The maximum number of nodes for IVS gpu job execution
+ivsGpuNodeCountMax = 2
+
+# The disk size in GiB of the nodes for the IVS gpu job execution
+ivsGpuNodeDiskSize = 100
+
+# Specifies whether an additional node pool for IVS gpu job execution is added to the kubernetes cluster
+ivsGpuNodePool = false
+
+# The machine size of the nodes for the IVS gpu job execution
+ivsGpuNodeSize = [
+    "g4dn.2xlarge"
+]
+
 # The NVIDIA driver version for GPU node group.
 gpuNvidiaDriverVersion = "535.54.03"
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -16,6 +16,9 @@ enable_ingress_nginx = false
 # Scans license server EC2 instance and EKS nodes for updates. Installs patches on license server automatically. EKS nodes need to be updated manually.
 enable_patching = false
 
+# Specifies whether an additional node pool for gpu job execution is added to the kubernetes cluster
+gpuNodePool = false
+
 # The maximum number of nodes for gpu job execution
 gpuNodeCountMax = 12
 
@@ -25,13 +28,13 @@ gpuNodeCountMin = 0
 # The disk size in GiB of the nodes for the gpu job execution
 gpuNodeDiskSize = 100
 
-# Specifies whether an additional node pool for gpu job execution is added to the kubernetes cluster
-gpuNodePool = false
-
 # The machine size of the nodes for the gpu job execution
 gpuNodeSize = [
   "p3.2xlarge"
 ]
+
+# Specifies whether an additional node pool for IVS gpu job execution is added to the kubernetes cluster
+ivsGpuNodePool = false
 
 # The minimum number of nodes for IVS gpu job execution
 ivsGpuNodeCountMin = 0
@@ -41,9 +44,6 @@ ivsGpuNodeCountMax = 2
 
 # The disk size in GiB of the nodes for the IVS gpu job execution
 ivsGpuNodeDiskSize = 100
-
-# Specifies whether an additional node pool for IVS gpu job execution is added to the kubernetes cluster
-ivsGpuNodePool = false
 
 # The machine size of the nodes for the IVS gpu job execution
 ivsGpuNodeSize = [

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,36 @@ variable "gpuNodeDiskSize" {
   default     = 100
 }
 
+variable "ivsGpuNodePool" {
+  type        = bool
+  description = "Specifies whether an additional node pool for IVS gpu job execution is added to the kubernetes cluster"
+  default     = false
+}
+
+variable "ivsGpuNodeSize" {
+  type        = list(string)
+  description = "The machine size of the GPU nodes for IVS jobs"
+  default     = ["g4dn.2xlarge"]
+}
+
+variable "ivsGpuNodeCountMin" {
+  type        = number
+  description = "The minimum number of GPU nodes nodes for IVS jobs"
+  default     = 0
+}
+
+variable "ivsGpuNodeCountMax" {
+  type        = number
+  description = "The maximum number of GPU nodes nodes for IVS jobs"
+  default     = 2
+}
+
+variable "ivsGpuNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the nodes for the IVS gpu job execution"
+  default     = 100
+}
+
 variable "gpuNvidiaDriverVersion" {
   type        = string
   description = "The NVIDIA driver version for GPU node group."


### PR DESCRIPTION
Added separate node pool for IVS related GPU nodes.  
Follows current template, but is in separate pool to enable setting IVS and Exec nodes' GPU pools separately.  
Deployed cluster, no errors, nodepool is created etc.  
Templated across all use-cases, done correctly.  

Terraform v1.4.5  
on linux_amd64  
+ provider registry.terraform.io/gavinbunney/kubectl v1.14.0  
+ provider registry.terraform.io/hashicorp/aws v4.67.0  
+ provider registry.terraform.io/hashicorp/cloudinit v2.3.3  
+ provider registry.terraform.io/hashicorp/helm v2.12.1  
+ provider registry.terraform.io/hashicorp/http v3.4.1  
+ provider registry.terraform.io/hashicorp/kubernetes v2.25.2  
+ provider registry.terraform.io/hashicorp/local v2.4.1  
+ provider registry.terraform.io/hashicorp/null v3.2.2  
+ provider registry.terraform.io/hashicorp/random v3.6.0  
+ provider registry.terraform.io/hashicorp/time v0.10.0  
+ provider registry.terraform.io/hashicorp/tls v4.0.5  
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1  
  