### PR TITLE
Upgrade PSQL to v16

### DIFF
--- a/modules/simphera_aws_instance/postgresql.tf
+++ b/modules/simphera_aws_instance/postgresql.tf
@@ -1,8 +1,25 @@
+#resource "aws_db_parameter_group" "default" {
+#  name_prefix = "rds-psql"
+#  family      = "postgres16"
+#
+#  parameter {
+#    name  = "log_connections"
+#    value = "1"
+#  }
+#
+#  lifecycle {
+#    create_before_destroy = true
+#  }
+#}
+
 resource "aws_db_instance" "simphera" {
 
+  #parameter_group_name                = aws_db_parameter_group.default.name
+  apply_immediately                   = true
   allocated_storage                   = var.postgresqlStorage
   max_allocated_storage               = var.postgresqlMaxStorage
   auto_minor_version_upgrade          = true # [RDS.13] RDS automatic minor version upgrades should be enabled
+  allow_major_version_upgrade         = true
   engine                              = "postgres"
   engine_version                      = var.postgresqlVersion
   instance_class                      = var.db_instance_type_simphera
@@ -35,9 +52,13 @@ resource "aws_db_instance" "simphera" {
 }
 
 resource "aws_db_instance" "keycloak" {
+
+  #parameter_group_name                = aws_db_parameter_group.default.name
+  apply_immediately                   = true
   allocated_storage                   = var.postgresqlStorageKeycloak
   max_allocated_storage               = var.postgresqlMaxStorageKeycloak
   auto_minor_version_upgrade          = true # [RDS.13] RDS automatic minor version upgrades should be enabled
+  allow_major_version_upgrade         = true
   engine                              = "postgres"
   engine_version                      = var.postgresqlVersion
   instance_class                      = var.db_instance_type_keycloak

--- a/modules/simphera_aws_instance/variables.tf
+++ b/modules/simphera_aws_instance/variables.tf
@@ -24,6 +24,13 @@ variable "name" {
   description = "The name of the SIMPHERA instance. e.g. production"
 }
 
+variable "postgresqlApplyImmediately" {
+  type        = bool
+  description = "Apply PostgreSQL changes immediately (true) or during next maintenance window (false)"
+  default     = false
+
+}
+
 variable "postgresqlVersion" {
   type        = string
   description = "PostgreSQL Server version to deploy"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -114,6 +114,7 @@ simpheraInstances = {
     "enable_deletion_protection" : true,
     "k8s_namespace" : "simphera",
     "name" : "production",
+    "postgresqlApplyImmediately" : false
     "postgresqlMaxStorage" : 100,
     "postgresqlMaxStorageKeycloak" : 100,
     "postgresqlStorage" : 20,

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,7 @@ variable "map_users" {
 variable "simpheraInstances" {
   type = map(object({
     name                         = string
+    postgresqlApplyImmediately   = bool
     postgresqlVersion            = string
     postgresqlStorage            = number
     postgresqlMaxStorage         = number
@@ -206,6 +207,7 @@ variable "simpheraInstances" {
   default = {
     "production" = {
       name                         = "production"
+      postgresqlApplyImmediately   = false
       postgresqlVersion            = "11"
       postgresqlStorage            = 20
       postgresqlMaxStorage         = 100


### PR DESCRIPTION
Upgrade of PSQL engine to v16 in ref arch, to avoid running into extended support for v11 (28th of Feb).  
Have also introduced a config option to apply maintenance change immediately (like major version upgrade), to avoid waiting for next maintenance window.  
Also tested an option to have parameter group(s), but is not part of this PR.  
Tested with clean deployment of v16 and also upgrade path from v11 to v16 (downgrade is not supported).  

Terraform v1.7.1
on linux_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.14.0
+ provider registry.terraform.io/hashicorp/aws v4.67.0
+ provider registry.terraform.io/hashicorp/cloudinit v2.3.3
+ provider registry.terraform.io/hashicorp/helm v2.12.1
+ provider registry.terraform.io/hashicorp/http v3.4.1
+ provider registry.terraform.io/hashicorp/kubernetes v2.25.2
+ provider registry.terraform.io/hashicorp/local v2.4.1
+ provider registry.terraform.io/hashicorp/null v3.2.2
+ provider registry.terraform.io/hashicorp/random v3.6.0
+ provider registry.terraform.io/hashicorp/time v0.10.0
+ provider registry.terraform.io/hashicorp/tls v4.0.5
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1
  