### PR TITLE
Added partial implementation of nginx metrics

### DIFF
--- a/templates/nginx_values.yaml
+++ b/templates/nginx_values.yaml
@@ -8,4 +8,9 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-internal: "${internal}"
       service.beta.kubernetes.io/aws-load-balancer-target-node-labels: kubernetes.io/os=linux
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
-
+  metrics:
+    enabled: true
+    port: 10254
+    portName: metrics
+    serviceMonitor:
+      enabled: false


### PR DESCRIPTION
This PR creates "metrics" service for nginx component (an add-on which is disabled by default).  
It also opens up "metrics" port on nginx pods (via deployment or daemonset), to which this service points to.  
Tested and verified, it does not impact default deployment of ref arch in any way.  
To make use of these monitoring enhancements, a Simphera Monitoring helm chart needs to be deployed with "nginx" section enabled and correctly set up (basically, using same labels and namespace as nginx component itself).  
This is done as a compromise between infra deployment and services on top of it.  

Terraform v1.7.1
on linux_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.14.0
+ provider registry.terraform.io/hashicorp/aws v4.67.0
+ provider registry.terraform.io/hashicorp/cloudinit v2.3.3
+ provider registry.terraform.io/hashicorp/helm v2.12.1
+ provider registry.terraform.io/hashicorp/http v3.4.1
+ provider registry.terraform.io/hashicorp/kubernetes v2.26.0
+ provider registry.terraform.io/hashicorp/local v2.4.1
+ provider registry.terraform.io/hashicorp/null v3.2.2
+ provider registry.terraform.io/hashicorp/random v3.6.0
+ provider registry.terraform.io/hashicorp/time v0.10.0
+ provider registry.terraform.io/hashicorp/tls v4.0.5
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1