### PR TITLE
Add missing attribute to simpheraInstances object

### DIFF
--- a/terraform.json.example
+++ b/terraform.json.example
@@ -47,6 +47,7 @@
       "db_instance_type_simphera": "db.t3.large",
       "enable_backup_service": true,
       "enable_deletion_protection": true,
+      "enable_keycloak": true,
       "k8s_namespace": "simphera",
       "name": "production",
       "postgresqlApplyImmediately": false,

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -110,6 +110,7 @@ simpheraInstances = {
     "db_instance_type_simphera": "db.t3.large",
     "enable_backup_service": true,
     "enable_deletion_protection": true,
+    "enable_keycloak": true,
     "k8s_namespace": "simphera",
     "name": "production",
     "postgresqlApplyImmediately": false,


### PR DESCRIPTION
An attribute for enabling of keycloak, declared in [A switch to enable/disable keycloak DB #132](https://github.com/dspace-group/simphera-reference-architecture-aws/pull/132), was missing in terraform.tfvars.example simpheraInstances object