### PR TITLE
Fix missing autoscaler addon version

### DIFF
--- a/.github/workflows/qualitygate.yml
+++ b/.github/workflows/qualitygate.yml
@@ -58,17 +58,17 @@ jobs:
           output-method: inject
           git-push: "true"
 
-      - name: Terraform-docs Regenerate terraform.tfvars.example
-        uses: terraform-docs/gh-actions@v1.0.0
-        with:
-          working-dir: .
-          config-file: tfvars.hcl.terraform-docs.yml
-          output-file: terraform.tfvars.example
-          output-format: tfvars hcl
-          output-method: replace
-          template: |
-            {{ .Content }}
-          git-push: "true"
+      # - name: Terraform-docs Regenerate terraform.tfvars.example
+      #   uses: terraform-docs/gh-actions@v1.0.0
+      #   with:
+      #     working-dir: .
+      #     config-file: tfvars.hcl.terraform-docs.yml
+      #     output-file: terraform.tfvars.example
+      #     output-format: tfvars hcl
+      #     output-method: replace
+      #     template: |
+      #       {{ .Content }}
+      #     git-push: "true"
 
       - name: Terraform-docs Regenerate terraform.json.example
         uses: terraform-docs/gh-actions@v1.0.0

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -3,7 +3,9 @@
 cloudwatch_retention = 7
 
 # Cluster Autoscaler Helm Config
-cluster_autoscaler_helm_config = {}
+cluster_autoscaler_helm_config = {
+  version = "9.28.0"
+}
 
 # Install FluentBit to send container logs to CloudWatch.
 enable_aws_for_fluentbit = false

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -3,9 +3,7 @@
 cloudwatch_retention = 7
 
 # Cluster Autoscaler Helm Config
-cluster_autoscaler_helm_config = {
-  version = "9.28.0"
-}
+cluster_autoscaler_helm_config = {}
 
 # Install FluentBit to send container logs to CloudWatch.
 enable_aws_for_fluentbit = false

--- a/variables.tf
+++ b/variables.tf
@@ -258,7 +258,5 @@ variable "cloudwatch_retention" {
 variable "cluster_autoscaler_helm_config" {
   type        = any
   description = "Cluster Autoscaler Helm Config"
-  default     = {
-    version = "9.28.0"
-  }
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -258,5 +258,7 @@ variable "cloudwatch_retention" {
 variable "cluster_autoscaler_helm_config" {
   type        = any
   description = "Cluster Autoscaler Helm Config"
-  default     = {}
+  default     = {
+    version = "9.28.0"
+  }
 }


### PR DESCRIPTION
Autoscaler addon config was removed in one of the previous PRs and now deployment fails because the default version is using registry that is deprecated.