### PR TITLE
Fix for autoscaler after qualitygate re-enable

### DIFF
--- a/.github/workflows/qualitygate.yml
+++ b/.github/workflows/qualitygate.yml
@@ -58,17 +58,17 @@ jobs:
           output-method: inject
           git-push: "true"
 
-      # - name: Terraform-docs Regenerate terraform.tfvars.example
-      #   uses: terraform-docs/gh-actions@v1.0.0
-      #   with:
-      #     working-dir: .
-      #     config-file: tfvars.hcl.terraform-docs.yml
-      #     output-file: terraform.tfvars.example
-      #     output-format: tfvars hcl
-      #     output-method: replace
-      #     template: |
-      #       {{ .Content }}
-      #     git-push: "true"
+      - name: Terraform-docs Regenerate terraform.tfvars.example
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+           working-dir: .
+           config-file: tfvars.hcl.terraform-docs.yml
+           output-file: terraform.tfvars.example
+           output-format: tfvars hcl
+           output-method: replace
+           template: |
+             {{ .Content }}
+           git-push: "true"
 
       - name: Terraform-docs Regenerate terraform.json.example
         uses: terraform-docs/gh-actions@v1.0.0

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
-| <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
+| <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | <pre>{<br>  "version": "9.28.0"<br>}</pre> | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_patching"></a> [enable\_patching](#input\_enable\_patching) | Scans license server EC2 instance and EKS nodes for updates. Installs patches on license server automatically. EKS nodes need to be updated manually. | `bool` | `false` | no |

--- a/terraform.json.example
+++ b/terraform.json.example
@@ -1,6 +1,8 @@
 {
   "cloudwatch_retention": 7,
-  "cluster_autoscaler_helm_config": {},
+  "cluster_autoscaler_helm_config": {
+    "version": "9.28.0"
+  },
   "enable_aws_for_fluentbit": false,
   "enable_ingress_nginx": false,
   "enable_patching": false,

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -4,7 +4,7 @@ cloudwatch_retention = 7
 
 # Cluster Autoscaler Helm Config
 cluster_autoscaler_helm_config = {
-  version = "9.28.0"
+  "version": "9.28.0"
 }
 
 # Install FluentBit to send container logs to CloudWatch.

--- a/variables.tf
+++ b/variables.tf
@@ -258,5 +258,5 @@ variable "cloudwatch_retention" {
 variable "cluster_autoscaler_helm_config" {
   type        = any
   description = "Cluster Autoscaler Helm Config"
-  default     = {version = "9.28.0"}
+  default     = { version = "9.28.0" }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -258,5 +258,5 @@ variable "cloudwatch_retention" {
 variable "cluster_autoscaler_helm_config" {
   type        = any
   description = "Cluster Autoscaler Helm Config"
-  default     = { "version": "9.28.0" }
+  default     = { "version" : "9.28.0" }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -258,5 +258,5 @@ variable "cloudwatch_retention" {
 variable "cluster_autoscaler_helm_config" {
   type        = any
   description = "Cluster Autoscaler Helm Config"
-  default     = {}
+  default     = {version = "9.28.0"}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -258,5 +258,5 @@ variable "cloudwatch_retention" {
 variable "cluster_autoscaler_helm_config" {
   type        = any
   description = "Cluster Autoscaler Helm Config"
-  default     = { version = "9.28.0" }
+  default     = { "version": "9.28.0" }
 }


### PR DESCRIPTION
After qualitygate was fixed in https://github.com/dspace-group/simphera-reference-architecture-aws/pull/131 , default autoscaler version was pulled from variables.tf (which references old registry and does not work - fixed in https://github.com/dspace-group/simphera-reference-architecture-aws/pull/123) and persisted in re-generated terrform.tfvars.example file (as part of qualitygate process).

This PR puts minimum default (working) version in variables.tf to avoid this situation; use tfvars file to adapt to your specific deployment, if necessary.