### PR TITLE
Optimize license server - CodeMeter runtime is automatically installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Charges may apply for the following AWS resources and services:
 | Amazon Simple Storage Service | Binary artifacts are stored in an S3 bucket. | Yes |
 | Amazon Elastic File System | Binary artifacts are stored temporarily in EFS. | Yes |
 | AWS Key Management Service (AWS KMS) | Encryption for Kubernetes secrets is enabled by default. | |
-| Amazon Elastic Compute Cloud | Optionally, you can deploy a dSPACE license server on an EC2 instance. Alternatively, you can deploy the server on external infrastructure. ||
+| Amazon Elastic Compute Cloud | Optionally, you can deploy a dSPACE license server on an EC2 instance. Alternatively, you can deploy the server on external infrastructure. For additional information, please contact our support team. ||
 | Amazon CloudWatch | Metrics and container logs to CloudWatch. It is recommended to deploy the dSPACE monitoring stack in Kubernetes.||
 
 ## Usage Instructions

--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
 | <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | <pre>{<br>  "version": "9.28.0"<br>}</pre> | no |
+| <a name="input_codemeter"></a> [codemeter](#input\_codemeter) | Download link for codemeter rpm package. | `string` | `"https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"` | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_patching"></a> [enable\_patching](#input\_enable\_patching) | Scans license server EC2 instance and EKS nodes for updates. Installs patches on license server automatically. EKS nodes need to be updated manually. | `bool` | `false` | no |

--- a/license-server.tf
+++ b/license-server.tf
@@ -26,6 +26,7 @@ resource "aws_instance" "license_server" {
                 systemctl stop codemeter
                 sed -i -e '/IsNetworkServer=/ s/=.*/=1/' /etc/wibu/CodeMeter/Server.ini
                 systemctl start codemeter
+                systemctl enable codemeter
                 EOF
 }
 

--- a/license-server.tf
+++ b/license-server.tf
@@ -17,7 +17,16 @@ resource "aws_instance" "license_server" {
       ami,
     ]
   }
-  tags = merge(var.tags, { "Name" = local.license_server, "Patch Group" = local.patchgroupid })
+  tags      = merge(var.tags, { "Name" = local.license_server, "Patch Group" = local.patchgroupid })
+  user_data = <<-EOF
+                #!/bin/bash
+                yum update -y
+                wget -O CodeMeter.rpm "${var.codemeter}"
+                yum -y localinstall CodeMeter.rpm
+                systemctl stop codemeter
+                sed -i -e '/IsNetworkServer=/ s/=.*/=1/' /etc/wibu/CodeMeter/Server.ini
+                systemctl start codemeter
+                EOF
 }
 
 data "aws_ami" "amazon_linux_kernel5" {
@@ -25,12 +34,7 @@ data "aws_ami" "amazon_linux_kernel5" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-kernel-5*"]
-  }
-
-  filter {
-    name   = "block-device-mapping.volume-type"
-    values = ["gp2"]
+    values = ["al2023-ami-202*"]
   }
 
   filter {

--- a/terraform.json.example
+++ b/terraform.json.example
@@ -3,6 +3,7 @@
   "cluster_autoscaler_helm_config": {
     "version": "9.28.0"
   },
+  "codemeter": "https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd",
   "enable_aws_for_fluentbit": false,
   "enable_ingress_nginx": false,
   "enable_patching": false,

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -7,6 +7,9 @@ cluster_autoscaler_helm_config = {
   "version": "9.28.0"
 }
 
+# Download link for codemeter rpm package.
+codemeter = "https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"
+
 # Install FluentBit to send container logs to CloudWatch.
 enable_aws_for_fluentbit = false
 

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,12 @@ variable "licenseServer" {
   default     = false
 }
 
+variable "codemeter" {
+  type        = string
+  description = "Download link for codemeter rpm package."
+  default     = "https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"
+}
+
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the EKS cluster."


### PR DESCRIPTION
- Licenses server uses the latest AMAZON Linux 2023 version
- CodeMeter User Runtime for Linux (Driver Only) version is automatically installed through user data
    Default version used : 8.10 | Driver Only | 2024-04-24 | multi language | Linux 64 bit RPM package 
- After installation, the license server is configured as network license server
 