### PR TITLE
Modify terraform-docs tfvars config file

### DIFF
--- a/.github/workflows/qualitygate.yml
+++ b/.github/workflows/qualitygate.yml
@@ -35,13 +35,13 @@ jobs:
 
       - name: Terraform validate
         run: terraform validate
-        
+
       - name: Init TFLint
         run: tflint --init
 
       - name: Terraform lint Root
         run: tflint
-      
+
       - name: Terraform lint SIMPHERA Base
         run: tflint --config ../../.tflint.hcl --chdir ./modules/simphera_aws_instance
 
@@ -64,7 +64,6 @@ jobs:
            working-dir: .
            config-file: tfvars.hcl.terraform-docs.yml
            output-file: terraform.tfvars.example
-           output-format: tfvars hcl
            output-method: replace
            template: |
              {{ .Content }}
@@ -79,5 +78,5 @@ jobs:
           output-method: replace
           template: |
             {{ .Content }}
-          git-push: "true"  
+          git-push: "true"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     -   id: tfsec
         name: tfsec
         entry: --entrypoint /src/hooks/tfsec.sh aquasec/tfsec:v1.28
-        language: docker_image                         
+        language: docker_image
 -   repo: local
     hooks:
     -   id: terraform_docs

--- a/hooks/terraform_docs.sh
+++ b/hooks/terraform_docs.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-terraform-docs markdown table --output-file README.md --output-mode inject . 
+terraform-docs markdown table --output-file README.md --output-mode inject .
 terraform-docs -c tfvars.hcl.terraform-docs.yml .
-terraform-docs -c tfvars.json.terraform-docs.yml .
+terraform-docs tfvars json .

--- a/tfvars.hcl.terraform-docs.yml
+++ b/tfvars.hcl.terraform-docs.yml
@@ -1,2 +1,14 @@
+# Original template for content: https://github.com/terraform-docs/terraform-docs/blob/v0.16.0/format/templates/tfvars_hcl.tmpl
+
+formatter: asciidoc
+content: |
+  {{ if .Module.Inputs -}}
+    {{- range $index, $element := .Module.Inputs }}
+      {{ if $element.Description -}}
+        # {{ tostring $element.Description }}
+      {{ end -}}
+      {{ $element.Name }} = {{ $element.GetValue }}
+    {{ end -}}
+  {{- end -}}
 settings:
   description: true


### PR DESCRIPTION
This modification will improve terraform-docs with the option to set input variables as null for both both terraform.json.example and terraform.tfvars.example.

With these changes, [the issue of converting null to empty string](https://terraform-docs.io/how-to/generate-terraform-tfvars/) with:

`terraform-docs tfvars hcl [PATH]`

will be circumvented.