### PR TITLE
SIMPHERA pod can connect to the license server

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Important: During credentials rotation, SIMPHERA will not be available for a sho
 | <a name="module_eks"></a> [eks](#module\_eks) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git | v4.32.1 |
 | <a name="module_eks-addons"></a> [eks-addons](#module\_eks-addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons | v4.32.1 |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_security_group_license_server"></a> [security\_group\_license\_server](#module\_security\_group\_license\_server) | terraform-aws-modules/security-group/aws | ~> 4 |
 | <a name="module_simphera_instance"></a> [simphera\_instance](#module\_simphera\_instance) | ./modules/simphera_aws_instance | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | v3.11.0 |
 

--- a/license-server.tf
+++ b/license-server.tf
@@ -1,24 +1,17 @@
 resource "aws_instance" "license_server" {
-  count                = var.licenseServer ? 1 : 0
-  ami                  = data.aws_ami.amazon_linux_kernel5.id
-  instance_type        = "t3a.large"
-  iam_instance_profile = aws_iam_instance_profile.license_server_profile[0].name
-  subnet_id            = module.vpc.private_subnets[0]
-
+  count                  = var.licenseServer ? 1 : 0
+  ami                    = data.aws_ami.amazon_linux_kernel5.id
+  instance_type          = "t3a.large"
+  iam_instance_profile   = aws_iam_instance_profile.license_server_profile[0].name
+  subnet_id              = module.vpc.private_subnets[0]
+  vpc_security_group_ids = [module.security_group_license_server[0].security_group_id]
   metadata_options {
     # [EC2.8] EC2 instances should use IMDSv2
     # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8
     http_endpoint = "enabled"
     http_tokens   = "required" # Require session token for Instance Metadata Service Version 2 (IMDSv2)
   }
-
-  lifecycle {
-    ignore_changes = [
-      ami,
-    ]
-  }
-  tags                   = merge(var.tags, { "Name" = local.license_server, "Patch Group" = local.patchgroupid })
-  user_data              = <<-EOF
+  user_data = <<-EOF
                 #!/bin/bash
                 yum update -y
                 wget -O CodeMeter.rpm "${var.codemeter}"
@@ -28,7 +21,13 @@ resource "aws_instance" "license_server" {
                 systemctl start codemeter
                 systemctl enable codemeter
                 EOF
-  vpc_security_group_ids = [module.security_group_license_server[0].security_group_id]
+
+  lifecycle {
+    ignore_changes = [
+      ami,
+    ]
+  }
+  tags = merge(var.tags, { "Name" = local.license_server, "Patch Group" = local.patchgroupid })
 }
 
 data "aws_ami" "amazon_linux_kernel5" {


### PR DESCRIPTION

SIMPHERA pod can connect to the license server on port 22350

- There is a separate security group for the license server
-  Inbound -> TCP on port 22350 from kubernetes nodes security group
- Outbound -> All traffic to 0.0.0.0/0