### PR TITLE
Removed eks_addon lifecycle dependency on managed node lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,13 @@ Afterwards you can deploy the resources:
 terraform apply
 ```
 
-Terraform automatically loads the variables from your `terraform.tfvars` variable definition file.
-Installation times may very, but it is expected to take up to 30 min to complete the deployment.
-It is recommended to use AWS `admin` account, or ask your AWS administrator to assign necessary IAM roles and permissions to your user.
+Terraform automatically loads the variables from your `terraform.tfvars` variable definition file.  
+Installation times may very, but it is expected to take up to 30 min to complete the deployment.  
+Note that `eks-addons` module dependency on managed node group(s) is commented out in `k8s.tf` file. This might increase
+deployment time, as various addons might be provisioned before any actual K8s worker node starts, to complete addon deployment.  
+Default timeout for node/addon deployment is 20 minutes, so please be patient.  If this behaviour creates problems, you can
+always uncomment line `depends_on = [module.eks.managed_node_groups]`.  
+It is recommended to use AWS `admin` account, or ask your AWS administrator to assign necessary IAM roles and permissions to your user.  
 
 ### Destroy Infrastructure
 

--- a/k8s.tf
+++ b/k8s.tf
@@ -50,7 +50,7 @@ module "eks-addons" {
   }
 
   cluster_autoscaler_helm_config = var.cluster_autoscaler_helm_config
-  depends_on                     = [module.eks.managed_node_groups]
+  #depends_on                     = [module.eks.managed_node_groups]
 }
 
 


### PR DESCRIPTION
This PR is very simple, what it does is basically in the title - it removes K8s add-ons lifecycle dependency on managed node lifecycle.  
This dependency is useful on initial deployment, as it ensures faster deployment and everything is ordered (nodes are provisioned first, and then apps on top, ensuring everything is ready for clean app provisioning).  
This is, however, not useful if lifecycle operations need to be performed later on, eg configuration change of managed node group(s).  
The system then runs into 'catch 22' type of a problem: configuration change triggers node group re-deployment, which in turn triggers eks_addons re-deployment, but since addons contain critical apps (CNI, DNS etc.) to complete node group re-deployment, the provisioning fails.  
While this solution is far from ideal, there is an ongoing effort to re-write addons module into individual resources, which would also enable the usage of lifecycle meta argument.  
Other points-of-view are welcome.  
