### PR TITLE
Added ECR pull-through configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 5.37.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
@@ -454,6 +455,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.37.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.30.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules
 
@@ -476,15 +478,18 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | [aws_cloudwatch_log_group.flowlogs](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_install_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.ssm_scan_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecr_pull_through_cache_rule.dspacecloudreleases](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/ecr_pull_through_cache_rule) | resource |
 | [aws_efs_file_system.efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/efs_file_system) | resource |
 | [aws_efs_file_system_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/efs_file_system_policy) | resource |
 | [aws_efs_mount_target.mount_target](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/efs_mount_target) | resource |
 | [aws_flow_log.flowlog](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/flow_log) | resource |
 | [aws_iam_instance_profile.license_server_profile](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.ecr_policy](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.flowlogs_policy](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.license_server_policy](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_policy) | resource |
 | [aws_iam_role.flowlogs_role](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_role) | resource |
 | [aws_iam_role.license_server_role](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.eks-attach-ecr](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.flowlogs_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.license_server_ssm](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.minio_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/iam_role_policy_attachment) | resource |
@@ -497,6 +502,8 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | [aws_s3_bucket_policy.license_server_bucket_ssl](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.buckets_logs_access](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.bucket_logs_encryption](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_secretsmanager_secret.ecr_pullthroughcache_dspacecloudreleases](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.ecr_credentials](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_maintenance_window.install](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/ssm_maintenance_window) | resource |
 | [aws_ssm_maintenance_window.scan](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/ssm_maintenance_window) | resource |
 | [aws_ssm_maintenance_window_target.install](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/ssm_maintenance_window_target) | resource |
@@ -507,6 +514,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | [aws_ssm_patch_baseline.production](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/ssm_patch_baseline) | resource |
 | [aws_ssm_patch_group.patch_group](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/resources/ssm_patch_group) | resource |
 | [kubernetes_storage_class_v1.efs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
+| [random_string.policy_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_ami.al2gpu_ami](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/ami) | data source |
 | [aws_ami.amazon_linux_kernel5](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/availability_zones) | data source |
@@ -514,6 +522,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | [aws_eks_node_group.execnodes](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/eks_node_group) | data source |
 | [aws_eks_node_group.gpuexecnodes](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/eks_node_group) | data source |
 | [aws_eks_node_group.gpuivsnodes](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/eks_node_group) | data source |
+| [aws_iam_policy_document.eks_node_custom_inline_policy](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/region) | data source |
 | [aws_subnet.private_subnet](https://registry.terraform.io/providers/hashicorp/aws/5.37.0/docs/data-sources/subnet) | data source |
@@ -529,6 +538,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | <a name="input_cloudwatch_retention"></a> [cloudwatch\_retention](#input\_cloudwatch\_retention) | Global cloudwatch retention period for the EKS, VPC, SSM, and PostgreSQL logs. | `number` | `7` | no |
 | <a name="input_cluster_autoscaler_helm_config"></a> [cluster\_autoscaler\_helm\_config](#input\_cluster\_autoscaler\_helm\_config) | Cluster Autoscaler Helm Config | `any` | <pre>{<br>  "version": "9.34.1"<br>}</pre> | no |
 | <a name="input_codemeter"></a> [codemeter](#input\_codemeter) | Download link for codemeter rpm package. | `string` | `"https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"` | no |
+| <a name="input_ecr_pullthrough_cache_rule_config"></a> [ecr\_pullthrough\_cache\_rule\_config](#input\_ecr\_pullthrough\_cache\_rule\_config) | Specifies if ECR pull through cache rule and accompanying resources will be created. Key 'enable' indicates whether pull through cache rule needs to be enabled for the cluster. When 'enable' is set to 'true', key 'exist' indicates whether pull through cache rule already exists for region's private ECR. If key 'enable' is set to 'true', IAM policy will be attached to the cluster's nodes. Additionally, if 'exist' is set to 'false', credentials for upstream registry and pull through cache rule will be created | <pre>object({<br>    enable = bool<br>    exist  = bool<br>  })</pre> | <pre>{<br>  "enable": false,<br>  "exist": false<br>}</pre> | no |
 | <a name="input_enable_aws_for_fluentbit"></a> [enable\_aws\_for\_fluentbit](#input\_enable\_aws\_for\_fluentbit) | Install FluentBit to send container logs to CloudWatch. | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_ivs"></a> [enable\_ivs](#input\_enable\_ivs) | n/a | `bool` | `false` | no |
@@ -580,5 +590,6 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | <a name="output_database_endpoints"></a> [database\_endpoints](#output\_database\_endpoints) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_database_identifiers"></a> [database\_identifiers](#output\_database\_identifiers) | Identifiers of the SIMPHERA and Keycloak databases from all SIMPHERA instances. |
 | <a name="output_eks_cluster_id"></a> [eks\_cluster\_id](#output\_eks\_cluster\_id) | Amazon EKS Cluster Name |
+| <a name="output_pullthrough_cache_prefix"></a> [pullthrough\_cache\_prefix](#output\_pullthrough\_cache\_prefix) | n/a |
 | <a name="output_s3_buckets"></a> [s3\_buckets](#output\_s3\_buckets) | S3 buckets from all SIMPHERA instances. |
 <!-- END_TF_DOCS -->

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,68 @@
+# Create secret in AWS SecretsManager to store credentials for upstream repo
+resource "aws_secretsmanager_secret" "ecr_pullthroughcache_dspacecloudreleases" {
+  count                   = var.ecr_pullthrough_cache_rule_config.enable && !var.ecr_pullthrough_cache_rule_config.exist ? 1 : 0
+  name                    = "ecr-pullthroughcache/dspacecloudreleases"
+  recovery_window_in_days = 7
+  tags                    = var.tags
+}
+
+# Store data inside created secret
+resource "aws_secretsmanager_secret_version" "ecr_credentials" {
+  count     = var.ecr_pullthrough_cache_rule_config.enable && !var.ecr_pullthrough_cache_rule_config.exist ? 1 : 0
+  secret_id = aws_secretsmanager_secret.ecr_pullthroughcache_dspacecloudreleases[0].id
+  secret_string = jsonencode(
+    {
+      username    = null
+      accessToken = null
+    }
+  )
+}
+
+# Create pull-through rule for private ECR registry
+resource "aws_ecr_pull_through_cache_rule" "dspacecloudreleases" {
+  count                 = var.ecr_pullthrough_cache_rule_config.enable && !var.ecr_pullthrough_cache_rule_config.exist ? 1 : 0
+  ecr_repository_prefix = "dspacecloudreleases"
+  upstream_registry_url = "dspacecloudreleases.azurecr.io"
+  credential_arn        = aws_secretsmanager_secret.ecr_pullthroughcache_dspacecloudreleases[0].arn
+}
+
+# Data to create custom IAM policy (give permissions to create repositories and replicate images)
+data "aws_iam_policy_document" "eks_node_custom_inline_policy" {
+  count = var.ecr_pullthrough_cache_rule_config.enable ? 1 : 0
+  statement {
+    actions = [
+      "ecr:CreateRepository",
+      "ecr:ReplicateImage",
+      "ecr:BatchImportUpstreamImage"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+# Random suffix string for policy name
+resource "random_string" "policy_suffix" {
+  count   = var.ecr_pullthrough_cache_rule_config.enable ? 1 : 0
+  length  = 4
+  special = false
+}
+
+# Create IAM policy
+resource "aws_iam_policy" "ecr_policy" {
+  count       = var.ecr_pullthrough_cache_rule_config.enable ? 1 : 0
+  name        = "ecr_pullthrough_policy-${random_string.policy_suffix[0].result}"
+  description = "Policy to enable EKS nodes to create ECR pull-through repositories"
+  policy      = data.aws_iam_policy_document.eks_node_custom_inline_policy[0].json
+  tags        = var.tags
+}
+
+# Attach IAM policy to cluster role(s)
+resource "aws_iam_role_policy_attachment" "eks-attach-ecr" {
+  for_each   = var.ecr_pullthrough_cache_rule_config.enable ? module.eks.managed_node_groups[0] : {}
+  role       = each.value["managed_nodegroup_iam_role_name"][0]
+  policy_arn = aws_iam_policy.ecr_policy[0].arn
+}
+
+output "pullthrough_cache_prefix" {
+  value = var.ecr_pullthrough_cache_rule_config.enable ? "dspacecloudreleases" : null
+}

--- a/terraform.json.example
+++ b/terraform.json.example
@@ -4,6 +4,10 @@
     "version": "9.34.1"
   },
   "codemeter": "https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd",
+  "ecr_pullthrough_cache_rule_config": {
+    "enable": false,
+    "exist": false
+  },
   "enable_aws_for_fluentbit": false,
   "enable_ingress_nginx": false,
   "enable_ivs": false,

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -10,6 +10,16 @@ cluster_autoscaler_helm_config = {
 # Download link for codemeter rpm package.
 codemeter = "https://www.wibu.com/support/user/user-software/file/download/13346.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&cHash=8dba7ab094dec6267346f04fce2a2bcd"
 
+# Specifies if ECR pull through cache rule and accompanying resources will be created.
+# Key 'enable' indicates whether pull through cache rule needs to be enabled for the cluster.
+# When 'enable' is set to 'true', key 'exist' indicates whether pull through cache rule already exists for region's private ECR.
+# If key 'enable' is set to 'true', IAM policy will be attached to the cluster's nodes.
+# Additionally, if 'exist' is set to 'false', credentials for upstream registry and pull through cache rule will be created.
+ecr_pullthrough_cache_rule_config = {
+  "enable": false,
+  "exist": false
+}
+
 # Install FluentBit to send container logs to CloudWatch.
 enable_aws_for_fluentbit = false
 

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,19 @@ variable "vpcPublicSubnets" {
   default     = ["10.1.12.0/22", "10.1.16.0/22", "10.1.20.0/22"]
 }
 
+variable "ecr_pullthrough_cache_rule_config" {
+  type = object({
+    enable = bool
+    exist  = bool
+  })
+
+  description = "Specifies if ECR pull through cache rule and accompanying resources will be created. Key 'enable' indicates whether pull through cache rule needs to be enabled for the cluster. When 'enable' is set to 'true', key 'exist' indicates whether pull through cache rule already exists for region's private ECR. If key 'enable' is set to 'true', IAM policy will be attached to the cluster's nodes. Additionally, if 'exist' is set to 'false', credentials for upstream registry and pull through cache rule will be created"
+  default = {
+    enable = false
+    exist  = false
+  }
+}
+
 variable "enable_aws_for_fluentbit" {
   type        = bool
   description = "Install FluentBit to send container logs to CloudWatch."

--- a/versions.tf
+++ b/versions.tf
@@ -17,5 +17,10 @@ terraform {
       version = ">= 2.4.1"
     }
 
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+
   }
 }


### PR DESCRIPTION
As the title says, this will create ECR rule to set up pull-through cache in your private ECR registry.  
It includes necessary credentals' secret, IAM policy and the pull-through rule itself.  
The creation of resources is controlled through object variable.  
  
Actual functionality from EKS cluster (ie IAM permissions, usage of images from upstream repository in cluster) is tested.  
  
Terraform v1.9.4
on windows_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.14.0
+ provider registry.terraform.io/hashicorp/aws v5.37.0
+ provider registry.terraform.io/hashicorp/cloudinit v2.3.4
+ provider registry.terraform.io/hashicorp/helm v2.13.2
+ provider registry.terraform.io/hashicorp/http v3.4.3
+ provider registry.terraform.io/hashicorp/kubernetes v2.30.0
+ provider registry.terraform.io/hashicorp/local v2.5.1
+ provider registry.terraform.io/hashicorp/null v3.2.2
+ provider registry.terraform.io/hashicorp/random v3.6.2
+ provider registry.terraform.io/hashicorp/time v0.11.2
+ provider registry.terraform.io/hashicorp/tls v4.0.5
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1