### PR TITLE
Enable protection of licence server instance

### DIFF
--- a/license-server.tf
+++ b/license-server.tf
@@ -1,10 +1,11 @@
 resource "aws_instance" "license_server" {
-  count                  = var.licenseServer ? 1 : 0
-  ami                    = data.aws_ami.amazon_linux_kernel5.id
-  instance_type          = "t3a.large"
-  iam_instance_profile   = aws_iam_instance_profile.license_server_profile[0].name
-  subnet_id              = local.private_subnets[0]
-  vpc_security_group_ids = [module.security_group_license_server[0].security_group_id]
+  count                   = var.licenseServer ? 1 : 0
+  ami                     = data.aws_ami.amazon_linux_kernel5.id
+  instance_type           = "t3a.large"
+  iam_instance_profile    = aws_iam_instance_profile.license_server_profile[0].name
+  subnet_id               = local.private_subnets[0]
+  disable_api_termination = true
+  vpc_security_group_ids  = [module.security_group_license_server[0].security_group_id]
 
   metadata_options {
     # [EC2.8] EC2 instances should use IMDSv2


### PR DESCRIPTION
These changes ensure that the licence server is not accidentally deleted and the licences become invalid.

[disable_api_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#disable_api_termination) - (Optional) If true, enables [EC2 Instance Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination).