### PR TITLE
Implement multiline support for tfvars description

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -18,7 +18,9 @@ enable_ingress_nginx = false
 
 enable_ivs = false
 
-# Scans license server EC2 instance and EKS nodes for updates. Installs patches on license server automatically. EKS nodes need to be updated manually.
+# Scans license server EC2 instance and EKS nodes for updates.
+# Installs patches on license server automatically.
+# EKS nodes need to be updated manually.
 enable_patching = false
 
 # The maximum number of nodes for gpu job execution
@@ -79,7 +81,9 @@ linuxExecutionNodeCountMin = 0
 # The disk size in GiB of the nodes for the job execution
 linuxExecutionNodeDiskSize = 200
 
-# The machine size of the Linux nodes for the job execution, user must check the availability of the instance types for the region. The list is ordered by priority where the first instance type gets the highest priority. Instance types must fulfill the following requirements: 64 GB RAM, 16 vCPUs, at least 110 IPs, at least 2 availability zones.
+# The machine size of the Linux nodes for the job execution, user must check the availability of the instance types for the region.
+# The list is ordered by priority where the first instance type gets the highest priority.
+# Instance types must fulfill the following requirements: 64 GB RAM, 16 vCPUs, at least 110 IPs, at least 2 availability zones.
 linuxExecutionNodeSize = [
   "m6a.4xlarge",
   "m5a.4xlarge",
@@ -99,7 +103,9 @@ linuxNodeCountMin = 1
 # The disk size in GiB of the nodes for the regular services
 linuxNodeDiskSize = 200
 
-# The machine size of the Linux nodes for the regular services, user must check the availability of the instance types for the region. The list is ordered by priority where the first instance type gets the highest priority. Instance types must fulfill the following requirements: 64 GB RAM, 16 vCPUs, at least 110 IPs, at least 2 availability zones.
+# The machine size of the Linux nodes for the regular services, user must check the availability of the instance types for the region.
+# The list is ordered by priority where the first instance type gets the highest priority.
+# Instance types must fulfill the following requirements: 64 GB RAM, 16 vCPUs, at least 110 IPs, at least 2 availability zones.
 linuxNodeSize = [
   "m6a.4xlarge",
   "m5a.4xlarge",

--- a/tfvars.hcl.terraform-docs.yml
+++ b/tfvars.hcl.terraform-docs.yml
@@ -5,8 +5,8 @@ content: |
   {{ if .Module.Inputs -}}
     {{- range $index, $element := .Module.Inputs }}
       {{ if $element.Description -}}
-        {{ if gt (len $element.Description) 350 }}
-          {{- range $value := (tostring $element.Description | split ". ") }}# {{ $value }}.
+        {{ if gt (len $element.Description) 120 }}
+          {{- range $value := (tostring $element.Description | split ". ") }}# {{ trimSuffix "." $value }}.
         {{ end -}}
         {{ else -}}
           # {{ tostring $element.Description }}

--- a/tfvars.hcl.terraform-docs.yml
+++ b/tfvars.hcl.terraform-docs.yml
@@ -5,10 +5,15 @@ content: |
   {{ if .Module.Inputs -}}
     {{- range $index, $element := .Module.Inputs }}
       {{ if $element.Description -}}
-        # {{ tostring $element.Description }}
+        {{ if gt (len $element.Description) 350 }}
+          {{- range $value := (tostring $element.Description | split ". ") }}# {{ $value }}.
+        {{ end -}}
+        {{ else -}}
+          # {{ tostring $element.Description }}
+        {{ end -}}
       {{ end -}}
-      {{ $element.Name }} = {{ $element.GetValue }}
-    {{ end -}}
+      {{- $element.Name }} = {{ $element.GetValue }}
+    {{ end }}
   {{- end -}}
 settings:
   description: true


### PR DESCRIPTION
This PR introduces support for generating multiline descriptions in terraform.tfvars.example when variable description is longer than 120 characters.
If string is longer that 120 characters, string is separated into sentences (sliced on ". "). Each sentence is written in a new line, regardless the length.  