### PR TITLE
docs: avoid timeout error on creation of EFS storage class

### DIFF
--- a/providers.tf.example
+++ b/providers.tf.example
@@ -14,7 +14,13 @@ provider "aws" {
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
+
+  # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#exec-plugins
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--profile", "change_me", "--cluster-name", data.aws_eks_cluster.cluster.name]
+    command     = "aws"
+  }
 }
 
 provider "helm" {
@@ -22,8 +28,8 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.cluster.token
-    
-    # Uncomment if you run into Helm timeout issues on Linux 
+
+    # Uncomment if you run into Helm timeout issues on Linux
     #exec {
     #  api_version = "client.authentication.k8s.io/v1beta1"
     #  args        = ["eks", "--profile=change_me", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]


### PR DESCRIPTION
Updates the example for the `kubernetes` provider to avoid issues regarding _timeout_ errors when creating EFS storage class.