### PR TITLE
Implement separate ebs-csi add-on outside of blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - replaced terraform-aws-eks-blueprint addon cluster-autoscaler with module `modules/k8s_eks_addons/cluster-autoscaler.tf`
 - replaced terraform-aws-eks-blueprint addon coredns with module `modules/k8s_eks_addons/coredns.tf`
 - replaced terraform-aws-eks-blueprint addon kube_proxy with module `modules/k8s_eks_addons/kube-proxy.tf`
+- replaced terraform-aws-eks-blueprint addon ebs-csi-driver with module `modules/k8s_eks_addons/ebs-csi.tf`
 
 ## v0.2.0
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -150,3 +150,34 @@ terraform apply
 ```
 4. Remove `move.tf` file
 
+# Migrate ebs_csi addon to the module
+To migrate from terraform-aws-eks-blueprint addon ebs_csi to custom module `modules/k8s_eks_addons/ebs-csi.tf` follow steps:
+
+1. create 'move.tf' in repository root
+2. Add following code:
+```
+moved {
+  from =  module.eks-addons.module.aws_ebs_csi_driver[0].data.aws_eks_addon_version.this
+  to   = module.k8s_eks_addons.data.aws_eks_addon_version.aws_ebs_csi_driver
+}
+moved {
+  from = module.eks-addons.module.aws_ebs_csi_driver[0].aws_eks_addon.aws_ebs_csi_driver[0]
+  to   = module.k8s_eks_addons.aws_eks_addon.aws_ebs_csi_driver
+}
+moved {
+  from = module.eks-addons.module.aws_ebs_csi_driver[0].module.irsa_addon[0].aws_iam_role.irsa[0]
+  to   = module.k8s_eks_addons.aws_iam_role.ebs_csi_driver_role
+}
+moved {
+  from = module.eks-addons.module.aws_ebs_csi_driver[0].module.irsa_addon[0].aws_iam_role_policy_attachment.irsa[0]
+  to   = module.k8s_eks_addons.aws_iam_role_policy_attachment.ebs_csi_driver_policy_attachment
+}
+
+```
+3. Run command:
+```
+terraform apply
+```
+4. Remove `move.tf` file
+
+

--- a/k8s.tf
+++ b/k8s.tf
@@ -16,14 +16,13 @@ module "eks" {
 
 
 module "eks-addons" {
-  source                               = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.32.1"
-  eks_cluster_id                       = module.eks.eks_cluster_id
-  enable_amazon_eks_vpc_cni            = true
-  enable_aws_efs_csi_driver            = true
-  enable_amazon_eks_aws_ebs_csi_driver = true
-  enable_aws_load_balancer_controller  = false
-  enable_aws_for_fluentbit             = var.enable_aws_for_fluentbit
-  tags                                 = var.tags
+  source                              = "git::https://github.com/aws-ia/terraform-aws-eks-blueprints.git//modules/kubernetes-addons?ref=v4.32.1"
+  eks_cluster_id                      = module.eks.eks_cluster_id
+  enable_amazon_eks_vpc_cni           = true
+  enable_aws_efs_csi_driver           = true
+  enable_aws_load_balancer_controller = false
+  enable_aws_for_fluentbit            = var.enable_aws_for_fluentbit
+  tags                                = var.tags
   aws_for_fluentbit_helm_config = {
     values = [templatefile("${path.module}/templates/fluentbit_values.yaml", {
       aws_region           = data.aws_region.current.name,

--- a/modules/k8s_eks_addons/ebs-csi.tf
+++ b/modules/k8s_eks_addons/ebs-csi.tf
@@ -1,0 +1,70 @@
+locals {
+  aws_ebs_csi_addon_name      = "aws-ebs-csi-driver"
+  aws_ebs_csi_namespace       = "kube-system"
+  aws_ebs_csi_service_account = "${local.aws_ebs_csi_addon_name}-sa"
+}
+
+data "aws_eks_addon_version" "aws_ebs_csi_driver" {
+  addon_name         = local.aws_ebs_csi_addon_name
+  kubernetes_version = var.addon_context.eks_cluster_version
+}
+
+resource "aws_eks_addon" "aws_ebs_csi_driver" {
+  cluster_name                = var.addon_context.eks_cluster_id
+  addon_name                  = local.aws_ebs_csi_addon_name
+  addon_version               = data.aws_eks_addon_version.aws_ebs_csi_driver.version
+  service_account_role_arn    = aws_iam_role.ebs_csi_driver_role.arn
+  preserve                    = true
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  tags                        = var.addon_context.tags
+}
+
+resource "kubernetes_service_account" "ebs_csi_driver_sa" {
+  metadata {
+    name      = local.aws_ebs_csi_service_account
+    namespace = local.aws_ebs_csi_namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.ebs_csi_driver_role.arn
+    }
+  }
+}
+resource "aws_iam_role" "ebs_csi_driver_role" {
+  name        = format("%s-%s-%s", var.addon_context.eks_cluster_id, trimsuffix(local.aws_ebs_csi_service_account, "-sa"), "irsa")
+  description = "AWS IAM Role for the Kubernetes service account ${local.aws_ebs_csi_service_account}."
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "arn:${var.addon_context.aws_partition_id}:iam::${var.addon_context.aws_caller_identity_account_id}:oidc-provider/${var.addon_context.eks_oidc_issuer_url}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringLike" : {
+            "${var.addon_context.eks_oidc_issuer_url}:sub" : "system:serviceaccount:${local.aws_ebs_csi_namespace}:${local.aws_ebs_csi_service_account}",
+            "${var.addon_context.eks_oidc_issuer_url}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  force_detach_policies = true
+
+  tags = var.addon_context.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  role       = aws_iam_role.ebs_csi_driver_role.name
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR replaces terraform-aws-eks-blueprint ebs-csi with module modules/k8s_eks_addons/ebs-csi.tf