### PR TITLE
 Implements the sending of Kubernetes control plane logs to a CloudWatch log group

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -1,13 +1,15 @@
 module "eks" {
-  source          = "./modules/eks"
-  cluster_version = var.kubernetesVersion
-  cluster_name    = var.infrastructurename
-  vpc_id          = local.vpc_id
-  subnet_ids      = local.private_subnets
-  map_accounts    = var.map_accounts
-  map_users       = var.map_users
-  map_roles       = var.map_roles
-  tags            = var.tags
+  source                                 = "./modules/eks"
+  cluster_version                        = var.kubernetesVersion
+  cluster_name                           = var.infrastructurename
+  vpc_id                                 = local.vpc_id
+  subnet_ids                             = local.private_subnets
+  map_accounts                           = var.map_accounts
+  map_users                              = var.map_users
+  map_roles                              = var.map_roles
+  tags                                   = var.tags
+  cloudwatch_log_group_kms_key_id        = aws_kms_key.kms_key_cloudwatch_log_group.arn
+  cloudwatch_log_group_retention_in_days = var.cloudwatch_retention
 }
 
 # data "aws_eks_node_group" "default" {

--- a/modules/eks/cluster.tf
+++ b/modules/eks/cluster.tf
@@ -2,7 +2,7 @@ resource "aws_eks_cluster" "eks" {
   name                          = var.cluster_name
   role_arn                      = aws_iam_role.cluster_role.arn
   version                       = var.cluster_version
-  enabled_cluster_log_types     = []
+  enabled_cluster_log_types     = var.cluster_enabled_log_types
   bootstrap_self_managed_addons = false
 
   vpc_config {
@@ -38,6 +38,6 @@ resource "aws_eks_cluster" "eks" {
 
   depends_on = [
     aws_iam_role_policy_attachment.cluster_role,
-    # aws_cloudwatch_log_group.cluster
+    aws_cloudwatch_log_group.log_group
   ]
 }

--- a/modules/eks/logs-group.tf
+++ b/modules/eks/logs-group.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_log_group" "log_group" {
+  count = var.create_cloudwatch_log_group ? 1 : 0
+
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id
+
+  tags = var.tags
+}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -59,3 +59,28 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "create_cloudwatch_log_group" {
+  description = "Determines whether a log group is created for the cluster logs. If not, AWS will automatically create one if logging is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Number of days to retain log events. Default retention - 90 days"
+  type        = number
+  default     = 90
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
+  type        = string
+  default     = null
+}
+
+variable "cluster_enabled_log_types" {
+  description = "A list of the desired control plane logs to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
+  type        = list(string)
+  default     = ["audit", "api", "authenticator"]
+}
+


### PR DESCRIPTION
This PR implements the sending of Kubernetes control plane logs to a CloudWatch log group without relying on external Terraform modules

- the EKS events are collected in a cloud watch log group
- the retention period of the log group can be set via the variable
- the cloud watch log group is encrypted with the KMS key