### PR TITLE
Fix unreachable internet for node groups created from launch template

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -12,6 +12,9 @@ module "eks" {
   cloudwatch_log_group_kms_key_id        = aws_kms_key.kms_key_cloudwatch_log_group.arn
   cloudwatch_log_group_retention_in_days = var.cloudwatch_retention
   managed_node_groups                    = merge(local.default_managed_node_pools, var.gpuNodePool ? local.gpu_node_pool : {}, var.ivsGpuNodePool ? local.ivsgpu_node_pool : {})
+  # only primary cluster securty group is used for node groups
+  create_node_security_group    = false
+  create_cluster_security_group = false
 }
 
 data "aws_eks_node_group" "default" {


### PR DESCRIPTION
Current state of the terraform-aws-blueprints creates additional security groups for the cluster and nodes. These security groups are only applied to the node group if a node group has launch template. Such security group are not sufficient for SIMPHERA deployment. 
This PR removes creation and attachment of mentioned security groups to enable SIMPHERA to work correctly.
Removal of security groups does not affect node's security. Such configuration is already manually used as a fix. Also, primary cluster security group is still present and is attached to created node groups.

Terraform v1.9.4
on windows_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.14.0
+ provider registry.terraform.io/hashicorp/aws v5.37.0
+ provider registry.terraform.io/hashicorp/cloudinit v2.3.4
+ provider registry.terraform.io/hashicorp/helm v2.13.2
+ provider registry.terraform.io/hashicorp/http v3.4.3
+ provider registry.terraform.io/hashicorp/kubernetes v2.30.0
+ provider registry.terraform.io/hashicorp/local v2.5.1
+ provider registry.terraform.io/hashicorp/null v3.2.2
+ provider registry.terraform.io/hashicorp/random v3.6.2
+ provider registry.terraform.io/hashicorp/tls v4.0.5
+ provider registry.terraform.io/terraform-aws-modules/http v2.4.1