### PR TITLE
Fix nodegroup roles ids and eks deployment

### DIFF
--- a/ivs-instances.tf
+++ b/ivs-instances.tf
@@ -4,9 +4,11 @@ module "ivs_instance" {
   tags              = var.tags
   dataBucketName    = each.value.dataBucketName
   rawDataBucketName = each.value.rawDataBucketName
-  nodeRoleNames = contains(
-    keys(module.eks.node_groups[0]), "gpuivsnodes") ? merge(
-    local.ivs_managed_nodegroup_role_Names,
-    { gpuivsnodes = module.eks.node_groups[0]["gpuivsnodes"].nodegroup_role_id }
-  ) : local.ivs_managed_nodegroup_role_Names
+  nodeRoleNames = merge(
+    {
+      default   = module.eks.node_groups[0]["default"].nodegroup_role_id
+      execnodes = module.eks.node_groups[0]["execnodes"].nodegroup_role_id
+    },
+    var.ivsGpuNodePool ? { gpuivsnodes = module.eks.node_groups[0]["gpuivsnodes"].nodegroup_role_id } : {}
+  )
 }

--- a/ivs-instances.tf
+++ b/ivs-instances.tf
@@ -4,9 +4,9 @@ module "ivs_instance" {
   tags              = var.tags
   dataBucketName    = each.value.dataBucketName
   rawDataBucketName = each.value.rawDataBucketName
-  nodeRoleNames = compact([
-    module.eks.node_groups[0]["default"].nodegroup_role_id,
-    module.eks.node_groups[0]["execnodes"].nodegroup_role_id,
-    contains(keys(module.eks.node_groups[0]), "gpuivsnodes") ? module.eks.node_groups[0]["gpuivsnodes"].nodegroup_role_id : null
-  ])
+  nodeRoleNames = contains(
+    keys(module.eks.node_groups[0]), "gpuivsnodes") ? merge(
+    local.ivs_managed_nodegroup_role_Names,
+    { gpuivsnodes = module.eks.node_groups[0]["gpuivsnodes"].nodegroup_role_id }
+  ) : local.ivs_managed_nodegroup_role_Names
 }

--- a/ivs-instances.tf
+++ b/ivs-instances.tf
@@ -4,11 +4,5 @@ module "ivs_instance" {
   tags              = var.tags
   dataBucketName    = each.value.dataBucketName
   rawDataBucketName = each.value.rawDataBucketName
-  nodeRoleNames = merge(
-    {
-      default   = module.eks.node_groups[0]["default"].nodegroup_role_id
-      execnodes = module.eks.node_groups[0]["execnodes"].nodegroup_role_id
-    },
-    var.ivsGpuNodePool ? { gpuivsnodes = module.eks.node_groups[0]["gpuivsnodes"].nodegroup_role_id } : {}
-  )
+  nodeRoleNames     = local.ivs_node_groups_roles
 }

--- a/locals.tf
+++ b/locals.tf
@@ -117,9 +117,4 @@ locals {
     region_name                = data.aws_region.current.name
     iam_issuer_arn             = data.aws_iam_session_context.current.issuer_arn
   }
-
-  ivs_managed_nodegroup_role_Names = {
-    default   = module.eks.node_groups[0]["default"].nodegroup_role_id
-    execnodes = module.eks.node_groups[0]["execnodes"].nodegroup_role_id
-  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -109,6 +109,13 @@ locals {
     }
   }
   node_pools = merge(local.default_node_pools, var.gpuNodePool ? local.gpu_node_pool : {}, var.ivsGpuNodePool ? local.ivsgpu_node_pool : {})
+  ivs_node_groups_roles = merge(
+    {
+      default   = module.eks.node_groups[0]["default"].nodegroup_role_id
+      execnodes = module.eks.node_groups[0]["execnodes"].nodegroup_role_id
+    },
+    var.ivsGpuNodePool ? { gpuivsnodes = module.eks.node_groups[0]["gpuivsnodes"].nodegroup_role_id } : {}
+  )
   aws_context = {
     caller_identity_account_id = data.aws_caller_identity.current.account_id
     partition_dns_suffix       = data.aws_partition.current.dns_suffix

--- a/locals.tf
+++ b/locals.tf
@@ -117,4 +117,9 @@ locals {
     region_name                = data.aws_region.current.name
     iam_issuer_arn             = data.aws_iam_session_context.current.issuer_arn
   }
+
+  ivs_managed_nodegroup_role_Names = {
+    default   = module.eks.node_groups[0]["default"].nodegroup_role_id
+    execnodes = module.eks.node_groups[0]["execnodes"].nodegroup_role_id
+  }
 }

--- a/modules/eks/cluster.tf
+++ b/modules/eks/cluster.tf
@@ -26,7 +26,7 @@ resource "aws_eks_cluster" "eks" {
   }
   access_config {
     authentication_mode                         = "CONFIG_MAP"
-    bootstrap_cluster_creator_admin_permissions = false
+    bootstrap_cluster_creator_admin_permissions = true
   }
   tags = var.tags
 

--- a/modules/ivs_aws_instance/storage.tf
+++ b/modules/ivs_aws_instance/storage.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket" "rawdata_bucket" {
 }
 
 resource "aws_iam_role_policy" "eks_node_s3_access_policy" {
-  for_each = toset(var.nodeRoleNames)
+  for_each = var.nodeRoleNames
   role     = each.value
   name     = "s3-access-policy"
   policy   = <<EOF

--- a/modules/ivs_aws_instance/variables.tf
+++ b/modules/ivs_aws_instance/variables.tf
@@ -15,6 +15,6 @@ variable "rawDataBucketName" {
 }
 
 variable "nodeRoleNames" {
-  type        = list(string)
+  type        = map(string)
   description = "The names of IAM roles assigned to EKS cluster nodes."
 }


### PR DESCRIPTION
This PR introduces fix for bugs occurring when destroying or creating new deployments. 
Bugs:
- Terraform throws error that for_each cannot have key that will be known after apply
- aws_eks_cluster resource requires bootstrap_cluster_creator_admin_permissions to be set to `true` when authentication_mode is `CONFIG_MAP`

Tested by deploying and destroying infrastructure.

Terraform v1.9.4
on windows_amd64
+ provider registry.terraform.io/hashicorp/aws v5.60.0
+ provider registry.terraform.io/hashicorp/helm v2.13.2
+ provider registry.terraform.io/hashicorp/http v3.4.3
+ provider registry.terraform.io/hashicorp/kubernetes v2.30.0
+ provider registry.terraform.io/hashicorp/random v3.6.2
+ provider registry.terraform.io/hashicorp/tls v4.0.5