### PR TITLE
Increase terraform version to 1.5.0

### DIFF
--- a/.github/workflows/qualitygate.yml
+++ b/.github/workflows/qualitygate.yml
@@ -20,7 +20,7 @@ jobs:
         #   # The API token for a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file.
         #   cli_config_credentials_token: # optional
         #   # The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.
-          terraform_version: 1.3.0 # optional, default is latest
+          terraform_version: 1.5.0 # optional, default is latest
         #   # Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
         #   terraform_wrapper: # optional, default is true
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.13.2 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.19.0 |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Increased terraform version to 1.5.0 (due to usage of strcontains function). [1.5.0 changelog](https://github.com/hashicorp/terraform/blob/v1.5/CHANGELOG.md#150-june-12-2023)

Terraform v1.9.4
on windows_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.19.0
+ provider registry.terraform.io/hashicorp/aws v5.60.0
+ provider registry.terraform.io/hashicorp/helm v2.13.2
+ provider registry.terraform.io/hashicorp/http v3.4.3
+ provider registry.terraform.io/hashicorp/kubernetes v2.36.0
+ provider registry.terraform.io/hashicorp/random v3.6.2
+ provider registry.terraform.io/hashicorp/tls v4.0.5