### PR TITLE
Increase terraform version to 1.9.0

### DIFF
--- a/.github/workflows/qualitygate.yml
+++ b/.github/workflows/qualitygate.yml
@@ -20,7 +20,7 @@ jobs:
         #   # The API token for a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file.
         #   cli_config_credentials_token: # optional
         #   # The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.
-          terraform_version: 1.5.0 # optional, default is latest
+          terraform_version: 1.9.0 # optional, default is latest
         #   # Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
         #   terraform_wrapper: # optional, default is true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     hooks:
     -   id: terraform_format
         name: terraform_format
-        entry: --entrypoint /src/hooks/terraform_format.sh hashicorp/terraform:1.5.2
+        entry: --entrypoint /src/hooks/terraform_format.sh hashicorp/terraform:1.9.0
         language: docker_image
 -   repo: local
     hooks:
     -   id: terraform_validate
         name: terraform_validate
-        entry: "--entrypoint /src/hooks/terraform_validate.sh -v tfvalidate:/src/cache hashicorp/terraform:1.5.2"
+        entry: "--entrypoint /src/hooks/terraform_validate.sh -v tfvalidate:/src/cache hashicorp/terraform:1.9.0"
         language: docker_image
 -   repo: local
     hooks:
     -   id: tflint
         name: tflint
-        entry: --entrypoint /src/hooks/tflint.sh ghcr.io/terraform-linters/tflint:v0.48.0
+        entry: --entrypoint /src/hooks/tflint.sh ghcr.io/terraform-linters/tflint:v0.52.0
         language: docker_image
 -   repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Implemented deployment of an OpenSearch Domain for usage in IVS
 - Update default version for helm chart of `ingress-nginx` to `4.12.1` (controller version `1.12.1`)
+- Increase required terraform version to 1.9.0
 
 ## v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 | -- | -- |
 | AWS CLI | >=2.10.0 |
 | Helm | >=3.8.0 |
-| Terraform | >=1.5.0 |
+| Terraform | >=1.9.0 |
 | kubectl | >=1.27.0 |
 
 <!-- BEGIN_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Encryption is enabled at all AWS resources that are created by Terraform:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.13.2 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.19.0 |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This PR introduces update of required version of terraform.
See changes in version at changelog [1.9.0](https://github.com/hashicorp/terraform/blob/v1.9/CHANGELOG.md#190-june-26-2024).