### PR TITLE
Add common tags to autoscaling groups

### DIFF
--- a/modules/eks/modules/node-group/node-group.tf
+++ b/modules/eks/modules/node-group/node-group.tf
@@ -63,3 +63,13 @@ resource "aws_autoscaling_group_tag" "ephemeral_storage" {
     propagate_at_launch = true
   }
 }
+
+resource "aws_autoscaling_group_tag" "tags" {
+  for_each               = var.tags
+  autoscaling_group_name = aws_eks_node_group.node_group.resources[0].autoscaling_groups[0].name
+  tag {
+    key                 = each.key
+    value               = each.value
+    propagate_at_launch = true
+  }
+}


### PR DESCRIPTION
This PR adds common tags to the autoscaling groups.

Terraform v1.9.4
on windows_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.19.0
+ provider registry.terraform.io/hashicorp/aws v5.60.0
+ provider registry.terraform.io/hashicorp/helm v2.13.2
+ provider registry.terraform.io/hashicorp/http v3.4.3
+ provider registry.terraform.io/hashicorp/kubernetes v2.36.0
+ provider registry.terraform.io/hashicorp/random v3.6.2
+ provider registry.terraform.io/hashicorp/tls v4.0.5

