### PR TITLE
Dynamically set IAM policy name for S3 CSI Driver

### DIFF
--- a/modules/k8s_eks_addons/s3-csi.tf
+++ b/modules/k8s_eks_addons/s3-csi.tf
@@ -54,7 +54,7 @@ resource "aws_iam_role" "s3_csi_driver_role" {
 
 resource "aws_iam_policy" "Amazons3CSIDriverPolicy" {
   count       = var.s3_csi_config.enable ? 1 : 0
-  name        = "Amazons3CSIDriverPolicy"
+  name        = "${var.addon_context.eks_cluster_id}-s3-csi-driver-irsa"
   description = "Amazons3CSIDriverPolicy"
 
   policy = jsonencode({


### PR DESCRIPTION
The IAM policy for Amazon S3 CSI Driver is hardcoded which results in Terraform throwing an error that the IAM policy with the same name already exists. This occurs when there are multiple infrastructures provisioned on the same AWS account.  Hence this PR introduces a change set this name dynamically.