### PR TITLE
Remove condition for IVS data bucket access

### DIFF
--- a/modules/ivs_aws_instance/storage.tf
+++ b/modules/ivs_aws_instance/storage.tf
@@ -34,11 +34,6 @@ resource "aws_iam_role_policy" "eks_node_s3_access_policy" {
                 "${aws_s3_bucket.data_bucket.arn}",
                 "${aws_s3_bucket.rawdata_bucket.arn}"
             ],
-            "Condition": {
-                "StringEquals": {
-                    "${local.goofys_user_agent_name}"
-                }
-            }
         },
         {
             "Action": [
@@ -52,11 +47,6 @@ resource "aws_iam_role_policy" "eks_node_s3_access_policy" {
                 "${aws_s3_bucket.data_bucket.arn}/*",
                 "${aws_s3_bucket.rawdata_bucket.arn}/*"
             ],
-            "Condition": {
-                "StringEquals": {
-                    "${local.goofys_user_agent_name}"
-                }
-            }
         },
         {
             "Action": [
@@ -68,11 +58,6 @@ resource "aws_iam_role_policy" "eks_node_s3_access_policy" {
                 "${aws_s3_bucket.data_bucket.arn}/*",
                 "${aws_s3_bucket.rawdata_bucket.arn}/*"
             ],
-            "Condition": {
-                "StringEquals": {
-                    "${local.goofys_user_agent_name}"
-                }
-            }
         }
     ]
 }


### PR DESCRIPTION
This PR disables policy condition for accessing data and raw buckets used by IVS.

Terraform v1.9.4
on windows_amd64
+ provider registry.terraform.io/gavinbunney/kubectl v1.19.0
+ provider registry.terraform.io/hashicorp/aws v5.60.0
+ provider registry.terraform.io/hashicorp/helm v2.13.2
+ provider registry.terraform.io/hashicorp/http v3.4.3
+ provider registry.terraform.io/hashicorp/kubernetes v2.36.0
+ provider registry.terraform.io/hashicorp/random v3.6.2
+ provider registry.terraform.io/hashicorp/tls v4.0.5