### PR TITLE
Add "AWS Regions Supported" section to reference architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Charges may apply for the following AWS resources and services:
 
 dSPACE Cloud Products rely on a set of core AWS services that are included in all AWS Region launches. While Amazon Elastic File System (EFS) is not part of the initial core set, it may not be immediately available in newly launched AWS Regions. For GPU-based workloads and other node configurations, users must verify the availability of the required EC2 instance types in the selected region.
 
-
 ## Usage Instructions
 
 To create the AWS resources that are required for operating the dSPACE Cloud Products from your local administration PC, you need to accomplish the following tasks:


### PR DESCRIPTION
This PR adds a new section titled “AWS Regions Supported” to the reference architecture documentation. The section clarifies the regional availability of AWS services required for deploying dSPACE Cloud Products.

This addition aligns with AWS FTR feedback