### PR TITLE
chore: Make LBC depend on policy and SA

### DIFF
--- a/modules/k8s_eks_addons/load-balancer-controller.tf
+++ b/modules/k8s_eks_addons/load-balancer-controller.tf
@@ -422,4 +422,9 @@ resource "helm_release" "aws_load_balancer_controller" {
   ]
   description       = "AWS load balancer controller helm chart deployment configuration for ingress resources"
   dependency_update = true
+
+  depends_on = [
+    aws_iam_role_policy_attachment.aws_load_balancer_controller,
+    kubernetes_service_account_v1.aws_load_balancer_controller,
+  ]
 }


### PR DESCRIPTION
Motivation for this change is to make the AWS LBC creation and destruction more robust. 
Atleast for destroy, this will make sure that LBC can only be destroyed after the ingress controllers are removed. 
This will also make sure the LBC can remove any pending Load Balancers