### PR TITLE
fix: change deprecated tls_security_policy option

### DIFF
--- a/modules/ivs_aws_instance/opensearch.tf
+++ b/modules/ivs_aws_instance/opensearch.tf
@@ -18,7 +18,7 @@ resource "aws_opensearch_domain" "opensearch" {
   }
   domain_endpoint_options {
     enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+    tls_security_policy = "Policy-Min-TLS-1-2-PFS-2023-10"
   }
   cluster_config {
     instance_count         = var.opensearch.instance_count


### PR DESCRIPTION
Beginning April 20, 2026, AWS will be discontinuing support for Transport Layer Security (TLS) versions 1.0 and 1.1.
We have been using TLS policy "Policy-Min-TLS-1-0-2019-07" that supports TLS versions 1.0 and 1.1 on OpenSearch Service.

To ensure continuous access to OpenSearch Service domain, TLS policy is updated to support both TLS 1.2 and TLS 1.3 with minimum list of ciphers that adhere to perfect forward secrecy.